### PR TITLE
Adds a version of the Weapon Auto Selection Mod

### DIFF
--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -24,11 +24,8 @@ namespace GameMod
                 uConsole.RegisterCommand("toggle_hud", "Toggles some HUD elements", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdToggleHud)); 
 
                 Initialise();
-				if( MenuManager.opt_primary_autoswitch != 0 )
-				{
-					primarySwapFlag = false;
-					secondarySwapFlag = false;
-                    MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
+		if( primarySwapFlag || secondarySwapFlag ) {
+                    MenuManager.opt_primary_autoswitch = 0;
                 }
             }
 

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -591,7 +591,6 @@ namespace mod_WeaponSelection
             {
                 if (weapon.Equals(PrimaryPriorityArray[i])) return PrimaryNeverSelect[i];
             }
-            uConsole.Log("we shouldn't be here (1)");
             return false;
         }
 
@@ -604,7 +603,6 @@ namespace mod_WeaponSelection
                     if (sel.Equals(PrimaryPriorityArray[i])) return PrimaryPriorityArray[i];
                 }
             }
-            uConsole.Log("AUTOORDER-  This Case shouldnt be possible [Error 0]");
             return "a";
 
         }

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -1,0 +1,1213 @@
+﻿using Harmony;
+using Overload;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+using UnityEngine;
+
+namespace mod_WeaponSelection
+{
+    class MPAutoSelection
+    {
+
+        [HarmonyPatch(typeof(GameManager), "Start")]
+        internal class CommandsAndInitialisationPatch
+        {
+            private static void Postfix(GameManager __instance)
+            {
+                uConsole.RegisterCommand("toggleprimaryorder", "toggles all Weapon Selection logic related to primary weapons", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdTogglePrimary)); 
+                uConsole.RegisterCommand("togglesecondaryorder", "toggles all Weapon Selection logic related to secondary weapons", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdToggleSecondary)); 
+                uConsole.RegisterCommand("toggle_hud", "Toggles some HUD elements", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdToggleHud)); 
+
+                Initialise();
+                MenuManager.opt_primary_autoswitch = 0;  //TODO to implement: if the autoswitch /= 0 turn off the mod and if the mod gets turned on set autoswitch == 0
+            }
+
+            // COMMANDS
+            private static void CmdToggleHud()
+            {
+                miasmic = !miasmic;
+                uConsole.Log("Toggled HUD ! current state : " + miasmic);
+            }
+
+            private static void CmdTogglePrimary()
+            {
+                primarySwapFlag = !primarySwapFlag;
+                uConsole.Log("[WPS] Primary weapon swapping: " + primarySwapFlag);
+                MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
+            }
+
+            private static void CmdToggleSecondary()
+            {
+                secondarySwapFlag = !secondarySwapFlag;
+                uConsole.Log("[WPS] Secondary weapon swapping: " + secondarySwapFlag);
+                MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
+            }
+        }
+
+
+
+
+
+        [HarmonyPatch(typeof(UIElement), "DrawHUDArmor")]
+        internal class MaybeDrawHUDElement1
+        {
+            public static bool Prefix(UIElement __instance)
+            {
+                return !miasmic;
+            }
+        }
+
+        [HarmonyPatch(typeof(UIElement), "DrawHUDEnergyAmmo")]
+        internal class MaybeDrawHUDElement2
+        {
+            public static bool Prefix()
+            {
+                return !miasmic;
+            }
+        }
+
+        [HarmonyPatch(typeof(UIElement), "DrawHUDIndicators")]
+        internal class MaybeDrawHUDElement3
+        {
+            public static bool Prefix(UIElement __instance)
+            {
+                return !miasmic;
+            }
+        }
+
+
+
+
+
+
+
+        // Keeps track of what entry point was used to reach the customize menu
+        [HarmonyPatch(typeof(UIElement), "DrawMpPreMatchMenu")]
+        internal class ClientInLobby
+        {
+            public static void Postfix()
+            {
+                isCurrentlyInLobby = true;
+            }
+        }
+        // Keeps track of what entry point was used to reach the customize menu
+        [HarmonyPatch(typeof(UIElement), "DrawMpMenu")]
+        internal class ClientNotInLobby
+        {
+            public static void Postfix()
+            {
+                isCurrentlyInLobby = false;
+            }
+        }
+
+
+
+
+
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        //              INITIALISATION AND FETCH SETTINGS / PREFERENCES                  
+        /////////////////////////////////////////////////////////////////////////////////////
+        //TODO: Store and Read the preferences in a better way
+        public static void Initialise()
+        {
+            MenuManager.opt_primary_autoswitch = 0;
+            if (File.Exists(textFile))
+            {
+                readContent();
+            }
+            else
+            {
+
+                Debug.Log("-AUTOSELECTORDER- [ERROR] File does not exist. Creating default priority list");
+                createDefaultPriorityFile();
+                readContent();
+            }
+            isInitialised = true;
+        }
+
+        private static void createDefaultPriorityFile()
+        {
+            using (StreamWriter sw = File.CreateText(textFile))
+            {
+                sw.WriteLine("THUNDERBOLT");
+                sw.WriteLine("CYCLONE");
+                sw.WriteLine("DRILLER");
+                sw.WriteLine("IMPULSE");
+                sw.WriteLine("FLAK");
+                sw.WriteLine("CRUSHER");
+                sw.WriteLine("LANCER");
+                sw.WriteLine("REFLEX");
+                sw.WriteLine("DEVASTATOR");
+                sw.WriteLine("NOVA");
+                sw.WriteLine("TIMEBOMB");
+                sw.WriteLine("HUNTER");
+                sw.WriteLine("VORTEX");
+                sw.WriteLine("FALCON");
+                sw.WriteLine("MISSILE_POD");
+                sw.WriteLine("CREEPER");
+                sw.WriteLine(PrimaryNeverSelect[0]);
+                sw.WriteLine(PrimaryNeverSelect[1]);
+                sw.WriteLine(PrimaryNeverSelect[2]);
+                sw.WriteLine(PrimaryNeverSelect[3]);
+                sw.WriteLine(PrimaryNeverSelect[4]);
+                sw.WriteLine(PrimaryNeverSelect[5]);
+                sw.WriteLine(PrimaryNeverSelect[6]);
+                sw.WriteLine(PrimaryNeverSelect[7]);
+                sw.WriteLine(SecondaryNeverSelect[0]);
+                sw.WriteLine(SecondaryNeverSelect[1]);
+                sw.WriteLine(SecondaryNeverSelect[2]);
+                sw.WriteLine(SecondaryNeverSelect[3]);
+                sw.WriteLine(SecondaryNeverSelect[4]);
+                sw.WriteLine(SecondaryNeverSelect[5]);
+                sw.WriteLine(SecondaryNeverSelect[6]);
+                sw.WriteLine(SecondaryNeverSelect[7]);
+                sw.WriteLine(MPAutoSelection.primarySwapFlag);
+                sw.WriteLine(MPAutoSelection.secondarySwapFlag);
+                sw.WriteLine(MPAutoSelection.COswapToHighest);
+                sw.WriteLine(MPAutoSelection.patchPrevNext);
+                sw.WriteLine(MPAutoSelection.zorc);
+                sw.WriteLine(MPAutoSelection.miasmic);
+            }
+        }
+
+        private static bool stringToBool(string b)
+        {
+            if (b == "True")
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private static void readContent()
+        {
+            using (StreamReader file = new StreamReader(textFile))
+            {
+                int counter = 0;
+                string ln;
+
+
+
+                while ((ln = file.ReadLine()) != null)
+                {
+                    /// Contains the priorities of the primary weapons
+                    if (counter < 8)
+                    {
+                        if (ln == "THUNDERBOLT" | ln == "IMPULSE" | ln == "CYCLONE" | ln == "DRILLER" | ln == "LANCER" | ln == "REFLEX" | ln == "FLAK" | ln == "CRUSHER")
+                        {
+                            PrimaryPriorityArray[counter] = ln;
+                        }
+                        else
+                        {
+                            Debug.Log("-AUTOORDER- [ERROR](1) unexpected line content -> (content: " + ln + " )");
+                            return;
+                        }
+
+                    }
+
+                    /// Contains the priorities of the secondary weapons
+                    else if (counter < 16)
+                    {
+                        if (ln == "DEVASTATOR" | ln == "TIMEBOMB" | ln == "VORTEX" | ln == "NOVA" | ln == "HUNTER" | ln == "FALCON" | ln == "CREEPER" | ln == "MISSILE_POD")
+                        {
+                            SecondaryPriorityArray[counter - 8] = ln;
+                        }
+                        else
+                        {
+                            Debug.Log("-AUTOORDER- [ERROR](2) unexpected line content -> (content: " + ln + " )");
+                            return;
+                        }
+                    }
+
+                    /// Contains true/false whether primary priorities are neverselected
+                    else if (counter < 24)
+                    {
+                        if (ln == "True" || ln == "False")
+                        {
+                            PrimaryNeverSelect[counter - 16] = stringToBool(ln);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < 8; i++)
+                            {
+                                PrimaryNeverSelect[i] = false;
+                            }
+                        }
+                    }
+                    /// Contains true/false whether secondary priorities are neverselected
+                    else if (counter < 32)
+                    {
+                        if (ln == "True" || ln == "False")
+                        {
+                            SecondaryNeverSelect[counter - 24] = stringToBool(ln);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < 8; i++)
+                            {
+                                SecondaryNeverSelect[i] = false;
+                            }
+                        }
+                    }
+                    else if (counter == 32)
+                    {
+                        if (ln == "True" || ln == "False") { primarySwapFlag = stringToBool(ln); }
+                    }
+                    else if (counter == 33)
+                    {
+                        if (ln == "True" || ln == "False") { secondarySwapFlag = stringToBool(ln); }
+                    }
+                    else if (counter == 34)
+                    {
+                        if (ln == "True" || ln == "False") { COswapToHighest = stringToBool(ln); }
+                    }
+                    else if (counter == 35)
+                    {
+                        if (ln == "True" || ln == "False") { patchPrevNext = stringToBool(ln); }
+                    }
+                    else if (counter == 36)
+                    {
+                        if (ln == "True" || ln == "False") { zorc = stringToBool(ln); }
+                    }
+                    else if (counter == 37)
+                    {
+                        if (ln == "True" || ln == "False") { miasmic = stringToBool(ln); }
+                    }
+
+                    else
+                    {
+                        Debug.Log("-AUTOORDER- [ERROR](3) unexpected line content -> (content: " + ln + " : " + counter + " )");
+
+                        return;
+                    }
+                    counter++;
+                }
+                file.Close();
+
+            }
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        //              PRIMARY WEAPONS CHAIN                   
+        /////////////////////////////////////////////////////////////////////////////////////
+        // TODO: rewrite or never touch this
+
+
+        public static WeaponType returnNextPrimary(Player local, bool prev)
+        {
+            if (areThereAllowedPrimaries() && (local.m_ammo > 0 || local.m_energy > 0))
+            {
+                WeaponType currentWeapon = local.m_weapon_type;
+                String currentWeaponName = WeaponTypeToString(local.m_weapon_type);
+
+                int index = getWeaponPriority(local.m_weapon_type);
+                if (prev && !currentWeaponName.Equals(PrimaryPriorityArray[7]))
+                {
+                    index++;
+                    while (index < 8)
+                    {
+                        if (isWeaponAccessibleAndNotNeverselect(PrimaryPriorityArray[index]) && isThereAmmoForThisPrimary(PrimaryPriorityArray[index], local))
+                        {
+                            return stringToWeaponType(PrimaryPriorityArray[index]);
+                        }
+                        index++;
+                    }
+                }
+                else if (!prev && !currentWeaponName.Equals(PrimaryPriorityArray[0]))
+                {
+                    index--;
+                    while (index >= 0)
+                    {
+                        if (isWeaponAccessibleAndNotNeverselect(PrimaryPriorityArray[index]) && isThereAmmoForThisPrimary(PrimaryPriorityArray[index], local))
+                        {
+                            return stringToWeaponType(PrimaryPriorityArray[index]);
+                        }
+                        index--;
+                    }
+                }
+                return WeaponType.NUM;
+            }
+            else
+            {
+                return WeaponType.NUM;
+            }
+        }
+
+        public static WeaponType returnNextPrimary2(Player local, bool prev)
+        {
+            if (areThereAllowedPrimaries() && (local.m_ammo > 0 || local.m_energy > 0))
+            {
+                //WeaponType currentWeapon = local.m_weapon_type;
+                String currentWeaponName = WeaponTypeToString(local.m_weapon_type);
+
+                int index = 0;
+                while (!PrimaryPriorityArray[index].Equals(currentWeaponName) && index < 8)
+                {
+                    index++;
+                }
+                if (index == 8) return WeaponType.NUM;
+                else
+                {
+                    // switch to a lower prioritized weapon
+                    if (prev)
+                    {
+                        index++;
+                        while (index < 8)
+                        {
+                            if (isWeaponAccessibleAndNotNeverselect(PrimaryPriorityArray[index]) && isThereAmmoForThisPrimary(PrimaryPriorityArray[index], local))
+                            {
+                                return stringToWeaponType(PrimaryPriorityArray[index]);
+                            }
+                            index++;
+                        }
+                        return WeaponType.NUM;
+                    }
+                    // switch to higher prioritized weapon
+                    else
+                    {
+                        index--;
+                        while (index >= 0)
+                        {
+                            if (isWeaponAccessibleAndNotNeverselect(PrimaryPriorityArray[index]) && isThereAmmoForThisPrimary(PrimaryPriorityArray[index], local))
+                            {
+                                return stringToWeaponType(PrimaryPriorityArray[index]);
+                            }
+                            index--;
+                        }
+                        return WeaponType.NUM;
+                    }
+                }
+            }
+            else
+            {
+                return WeaponType.NUM;
+            }
+        }
+
+        public static bool isThereAmmoForThisPrimary(string weapon, Player local)
+        {
+            foreach (string ele in EnergyWeapons)
+            {
+                if (ele.Equals(weapon)) return local.m_energy > 0;
+            }
+            foreach (string ele in AmmoWeapons)
+            {
+                if (ele.Equals(weapon)) return local.m_ammo > 0;
+            }
+            return false;
+        }
+
+
+        public static WeaponType returnHighestAllowedPrimaryWithAmmo(Player local)
+        {
+            if (areThereAllowedPrimaries() && (local.m_ammo > 0 || local.m_energy > 0))
+            {
+                // find the highest primary of the energy weapons
+                string[] candidates = returnArrayOfUnlockedPrimaries(EnergyWeapons);
+                WeaponType highestEnergy = WeaponType.NUM;
+                if (candidates.Length > 0)
+                {
+                    string a = returnHighestPrimary(candidates);
+                    if (!a.Equals("a")) highestEnergy = stringToWeaponType(a);
+                }
+
+                // find the highest primary of the ammo weapons
+                candidates = returnArrayOfUnlockedPrimaries(AmmoWeapons);
+                WeaponType highestAmmo = WeaponType.NUM;
+                if (candidates.Length > 0)
+                {
+                    string a = returnHighestPrimary(candidates);
+                    if (!a.Equals("a")) highestAmmo = stringToWeaponType(a);
+                }
+
+                // check if one of the results is valid
+                if (highestEnergy == WeaponType.NUM && highestAmmo == WeaponType.NUM) return WeaponType.NUM;
+                else
+                {
+                    WeaponType first = WeaponType.NUM, second = WeaponType.NUM;
+                    foreach (String ele in PrimaryPriorityArray)
+                    {
+                        if (ele.Equals(WeaponTypeToString(highestEnergy)))
+                        {
+                            first = highestEnergy;
+                            second = highestAmmo;
+                            break;
+                        }
+                        if (ele.Equals(WeaponTypeToString(highestAmmo)))
+                        {
+                            first = highestAmmo;
+                            second = highestAmmo;
+                            break;
+                        }
+                    }
+                    if (first != WeaponType.NUM)
+                    {
+                        return first;
+                    }
+                    else
+                    {
+                        return second;
+                    }
+                }
+
+            }
+            else
+            {
+                return WeaponType.NUM;
+            }
+
+        }
+
+        public static void maybeSwapPrimary()
+        {
+            //is there even a potential static option to switch to
+            if (areThereAllowedPrimaries())
+            {
+                // case 0: energy but no ammo
+                if (GameManager.m_local_player.m_energy > 0 && !(GameManager.m_local_player.m_ammo > 0))
+                {
+                    //is there an unlocked energy weapon
+                    string[] candidates = returnArrayOfUnlockedPrimaries(EnergyWeapons);
+                    if (candidates.Length > 0)
+                    {
+                        string a = returnHighestPrimary(candidates);
+                        if (!a.Equals("a")) swapToWeapon(a);
+                    }
+                    else
+                    {
+                        swap_failed = true;
+                    }
+                    return;
+                }
+                // case 1: ammo but no energy
+                if (!(GameManager.m_local_player.m_energy > 0) && GameManager.m_local_player.m_ammo > 0)
+                {
+                    //is there an unlocked ammo weapon
+                    string[] candidates = returnArrayOfUnlockedPrimaries(AmmoWeapons);
+                    if (candidates.Length > 0)
+                    {
+                        string a = returnHighestPrimary(candidates);
+                        if (!a.Equals("a")) swapToWeapon(a);
+                    }
+                    else
+                    {
+                        swap_failed = true;
+                    }
+                    return;
+                }
+                // case 2: ammo and energy
+                //give me the highest unlocked weapon
+                string[] candidates1 = returnArrayOfUnlockedPrimaries(PrimaryPriorityArray);
+                if (candidates1.Length > 0)
+                {
+                    string a = returnHighestPrimary(candidates1);
+                    if (!a.Equals("a")) swapToWeapon(a);
+                }
+                return;
+            }
+        }
+
+        private static bool areThereAllowedPrimaries()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                if (PrimaryNeverSelect[i] == false) return true;
+            }
+            return false;
+        }
+
+        private static string[] returnArrayOfUnlockedPrimaries(string[] arr)
+        {
+            int len = arr.Length;
+            if (len > 0)
+            {
+                int counter = 0;
+                string[] temp = new string[len];
+                for (int i = 0; i < len; i++)
+                {
+                    if (isWeaponAccessibleAndNotNeverselect(arr[i]))
+                    {
+                        temp[counter] = arr[i];
+                        counter++;
+                    }
+                }
+                string[] result = new string[counter];
+                for (int j = 0; j < counter; j++)
+                {
+                    result[j] = temp[j];
+                }
+                return result;
+            }
+            return new string[0];
+        }
+
+        private static bool isWeaponAccessibleAndNotNeverselect(string weapon)
+        {
+            if (weapon.Equals("IMPULSE")) return !(GameManager.m_local_player.m_weapon_level[0].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("IMPULSE");
+            if (weapon.Equals("CYCLONE")) return !(GameManager.m_local_player.m_weapon_level[1].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("CYCLONE");
+            if (weapon.Equals("REFLEX")) return !(GameManager.m_local_player.m_weapon_level[2].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("REFLEX");
+            if (weapon.Equals("CRUSHER")) return !(GameManager.m_local_player.m_weapon_level[3].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("CRUSHER");
+            if (weapon.Equals("DRILLER")) return !(GameManager.m_local_player.m_weapon_level[4].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("DRILLER");
+            if (weapon.Equals("FLAK")) return !(GameManager.m_local_player.m_weapon_level[5].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("FLAK");
+            if (weapon.Equals("THUNDERBOLT")) return !(GameManager.m_local_player.m_weapon_level[6].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("THUNDERBOLT");
+            if (weapon.Equals("LANCER")) return !(GameManager.m_local_player.m_weapon_level[7].ToString().Equals("LOCKED")) && !isPrimaryOnNeverSelectList("LANCER");
+            else
+            {
+                return false;
+            }
+
+        }
+
+        private static bool isPrimaryOnNeverSelectList(string weapon)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                if (weapon.Equals(PrimaryPriorityArray[i])) return PrimaryNeverSelect[i];
+            }
+            uConsole.Log("we shouldn't be here (1)");
+            return false;
+        }
+
+        private static string returnHighestPrimary(string[] arr)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                foreach (string sel in arr)
+                {
+                    if (sel.Equals(PrimaryPriorityArray[i])) return PrimaryPriorityArray[i];
+                }
+            }
+            uConsole.Log("AUTOORDER-  This Case shouldnt be possible [Error 0]");
+            return "a";
+
+        }
+
+        private static void swapToWeapon(string weaponName)
+        {
+            if (!(GameManager.m_local_player.m_weapon_type.Equals(stringToWeaponType(weaponName))))
+            {
+                GameManager.m_local_player.Networkm_weapon_type = stringToWeaponType(weaponName);
+                GameManager.m_local_player.CallCmdSetCurrentWeapon(GameManager.m_local_player.m_weapon_type);
+                GameManager.m_player_ship.WeaponSelectFX();
+            }
+            SFXCueManager.PlayRawSoundEffect2D(SoundEffect.hud_notify_message1, 1f, 0.15f, 0.1f, false);
+        }
+
+        private static WeaponType stringToWeaponType(string weapon)
+        {
+            if (weapon.Equals("IMPULSE")) return WeaponType.IMPULSE;
+            if (weapon.Equals("CYCLONE")) return WeaponType.CYCLONE;
+            if (weapon.Equals("REFLEX")) return WeaponType.REFLEX;
+            if (weapon.Equals("CRUSHER")) return WeaponType.CRUSHER;
+            if (weapon.Equals("DRILLER")) return WeaponType.DRILLER;
+            if (weapon.Equals("FLAK")) return WeaponType.FLAK;
+            if (weapon.Equals("THUNDERBOLT")) return WeaponType.THUNDERBOLT;
+            if (weapon.Equals("LANCER")) return WeaponType.LANCER;
+            else
+            {
+                return WeaponType.NUM;
+            }
+        }
+
+        private static string WeaponTypeToString(WeaponType weapon)
+        {
+            if (weapon == WeaponType.IMPULSE) return "IMPULSE";
+            if (weapon == WeaponType.CYCLONE) return "CYCLONE";
+            if (weapon == WeaponType.REFLEX) return "REFLEX";
+            if (weapon == WeaponType.CRUSHER) return "CRUSHER";
+            if (weapon == WeaponType.DRILLER) return "DRILLER";
+            if (weapon == WeaponType.FLAK) return "FLAK";
+            if (weapon == WeaponType.THUNDERBOLT) return "THUNDERBOLT";
+            if (weapon == WeaponType.LANCER) return "LANCER";
+            if (weapon == WeaponType.NUM) return "NUM";
+            else
+            {
+                uConsole.Log("fired an end");
+                return "end";
+            }
+        }
+
+
+        public static int getWeaponPriority(WeaponType primary)
+        {
+            if (MPAutoSelection.isInitialised)
+            {
+                string wea = primary.ToString();
+
+                for (int i = 0; i < 8; i++)
+                {
+                    if (wea.Equals(PrimaryPriorityArray[i]))
+                    {
+                        return i;
+                    }
+                    if (wea.Equals("CRUSHER") && PrimaryPriorityArray[i].Equals("CRUSHER"))
+                    {
+                        return i;
+                    }
+                }
+                uConsole.Log("-AUTOSELECTORDER- [WARN]: getWeaponPriority:-1, primary wasnt in array");
+                return -1;
+            }
+            else
+            {
+                uConsole.Log("-AUTOSELECTORDER- [WARN]: getWeaponPriority:-1, priority didnt get initialised");
+                return -1;
+            }
+        }
+
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        //              MISSILES                 
+        /////////////////////////////////////////////////////////////////////////////////////
+        public static int getWeaponIndex(string weapon)
+        {
+            if (weapon.Equals("IMPULSE") || weapon.Equals("FALCON")) return 0;
+            if (weapon.Equals("CYCLONE") || weapon.Equals("MISSILE_POD")) return 1;
+            if (weapon.Equals("REFLEX") || weapon.Equals("HUNTER")) return 2;
+            if (weapon.Equals("CRUSHER") || weapon.Equals("CREEPER")) return 3;
+            if (weapon.Equals("DRILLER") || weapon.Equals("NOVA")) return 4;
+            if (weapon.Equals("FLAK") || weapon.Equals("DEVASTATOR")) return 5;
+            if (weapon.Equals("THUNDERBOLT") || weapon.Equals("TIMEBOMB")) return 6;
+            if (weapon.Equals("LANCER") || weapon.Equals("VORTEX")) return 7;
+            else
+            {
+                uConsole.Log("-AUTOORDERSELECT- [ERROR] getWeaponIndex didnt recognise the given weapon string");
+                return 0;
+            }
+        }
+
+        private static bool isMissileAccessibleAndNotNeverselect(string weapon)
+        {
+            if (weapon.Equals("FALCON")) return !(GameManager.m_local_player.m_missile_level[0].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("FALCON");
+            if (weapon.Equals("MISSILE_POD")) return !(GameManager.m_local_player.m_missile_level[1].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("MISSILE_POD");
+            if (weapon.Equals("HUNTER")) return !(GameManager.m_local_player.m_missile_level[2].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("HUNTER");
+            if (weapon.Equals("CREEPER")) return !(GameManager.m_local_player.m_missile_level[3].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("CREEPER");
+            if (weapon.Equals("NOVA")) return !(GameManager.m_local_player.m_missile_level[4].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("NOVA");
+            if (weapon.Equals("DEVASTATOR")) return !(GameManager.m_local_player.m_missile_level[5].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("DEVASTATOR");
+            if (weapon.Equals("TIMEBOMB")) return !(GameManager.m_local_player.m_missile_level[6].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("TIMEBOMB");
+            if (weapon.Equals("VORTEX")) return !(GameManager.m_local_player.m_missile_level[7].ToString().Equals("LOCKED")) && !isSecondaryOnNeverSelectList("VORTEX");
+            else
+            {
+                return false;
+            }
+
+        }
+
+        public static bool isSecondaryOnNeverSelectList(string weapon)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                if (weapon.Equals(SecondaryPriorityArray[i])) return SecondaryNeverSelect[i];
+            }
+            return false;
+        }
+
+        private static MissileType stringToMissileType(string weapon)
+        {
+            if (weapon.Equals("FALCON")) return MissileType.FALCON;
+            if (weapon.Equals("MISSILE_POD")) return MissileType.MISSILE_POD;
+            if (weapon.Equals("HUNTER")) return MissileType.HUNTER;
+            if (weapon.Equals("CREEPER")) return MissileType.CREEPER;
+            if (weapon.Equals("NOVA")) return MissileType.NOVA;
+            if (weapon.Equals("DEVASTATOR")) return MissileType.DEVASTATOR;
+            if (weapon.Equals("TIMEBOMB")) return MissileType.TIMEBOMB;
+            if (weapon.Equals("VORTEX")) return MissileType.VORTEX;
+            else
+            {
+                return MissileType.NUM;
+            }
+        }
+
+        public static MissileType returnNextSecondary(Player local, bool prev)
+        {
+            if (areThereAllowedSecondaries())
+            {
+                MissileType currentMissile = local.m_missile_type;
+                String currentMissileName = currentMissile.ToString();
+
+                int index = getMissilePriority(currentMissile);
+                if (prev && !currentMissileName.Equals(SecondaryPriorityArray[7]))
+                {
+                    index++;
+                    while (index < 8)
+                    {
+                        if (isMissileAccessibleAndNotNeverselect(SecondaryPriorityArray[index]) && local.m_missile_ammo[getWeaponIndex(SecondaryPriorityArray[index])] > 0)
+                        {
+                            return stringToMissileType(SecondaryPriorityArray[index]);
+                        }
+                        index++;
+                    }
+                }
+                else if (!prev && !currentMissileName.Equals(SecondaryPriorityArray[0]))
+                {
+                    index--;
+                    while (index >= 0)
+                    {
+                        if (isMissileAccessibleAndNotNeverselect(SecondaryPriorityArray[index]) && local.m_missile_ammo[getWeaponIndex(SecondaryPriorityArray[index])] > 0)
+                        {
+                            return stringToMissileType(SecondaryPriorityArray[index]);
+                        }
+                        index--;
+                    }
+                }
+                return MissileType.NUM;
+            }
+            else
+            {
+                return MissileType.NUM;
+            }
+        }
+
+        public static int getMissilePriority(MissileType missile)
+        {
+            if (MPAutoSelection.isInitialised)
+            {
+                string mis = missile.ToString();
+                for (int i = 0; i < 8; i++)
+                {
+                    if (mis.Equals(SecondaryPriorityArray[i]))
+                    {
+                        return i;
+                    }
+                }
+                uConsole.Log("-AUTOSELECTORDER- [WARN]: getMissilePriority:-1, primary wasnt in array");
+                return -1;
+            }
+            else
+            {
+                uConsole.Log("-AUTOSELECTORDER- [WARN]: getMissilePriority:-1, priority didnt get initialised");
+                return -1;
+            }
+
+        }
+
+        private static bool areThereAllowedSecondaries()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                if (SecondaryNeverSelect[i] == false) return true;
+            }
+            return false;
+        }
+
+        public static void maybeSwapMissiles()
+        {
+            int highestMissile = findHighestPrioritizedUseableMissile();
+            if (highestMissile == -1)
+            {
+                return;
+            }
+            else
+            {
+                swapToMissile(highestMissile);
+                return;
+            }
+
+        }
+
+        public static int findHighestPrioritizedUseableMissile()
+        {
+            foreach (string missile in SecondaryPriorityArray)
+            {
+                int var = missileStringToInt(missile);
+                if (GameManager.m_local_player.m_missile_ammo[var] > 0)
+                {
+                    return var;
+                }
+            }
+            return -1;
+        }
+
+        public static int findHighestPrevMissile()
+        {
+            int currentMissile = (int)GameManager.m_local_player.m_missile_type;
+            foreach (string missile in SecondaryPriorityArray)
+            {
+                int var = missileStringToInt(missile);
+                if (GameManager.m_local_player.m_missile_ammo[var] > 0 && var != currentMissile)
+                {
+                    return var;
+                }
+            }
+            return -1;
+        }
+
+        private static void swapToMissile(int weapon_num)
+        {
+            if (GameManager.m_local_player.m_missile_level[weapon_num] == WeaponUnlock.LOCKED || GameManager.m_local_player.m_missile_ammo[weapon_num] == 0)//GameManager.m_local_player.m_missile_ammo[weapon_num] == 0)
+            {
+                return;
+            }
+            if (GameManager.m_local_player.m_missile_type != (MissileType)weapon_num)
+            {
+                GameManager.m_local_player.Networkm_missile_type = (MissileType)weapon_num;
+                GameManager.m_local_player.CallCmdSetCurrentMissile(GameManager.m_local_player.Networkm_missile_type);
+                GameManager.m_player_ship.MissileSelectFX();
+                GameManager.m_local_player.UpdateCurrentMissileName();
+            }
+            if (MPAutoSelection.zorc)
+            {
+                if (IntToMissileType(weapon_num).Equals(MissileType.DEVASTATOR))
+                {
+                    SFXCueManager.PlayCue2D(SFXCue.enemy_boss1_alert, 1f, 0f, 0f, false);
+                    GameplayManager.AlertPopup(Loc.LS("DEVASTATOR SELECTED"), string.Empty, 5f);
+                }
+            }
+
+        }
+
+        public static int missileStringToInt(string missile)
+        {
+
+            if (missile.Equals("FALCON")) return 0;
+            if (missile.Equals("MISSILE_POD")) return 1;
+            if (missile.Equals("HUNTER")) return 2;
+            if (missile.Equals("CREEPER")) return 3;
+            if (missile.Equals("NOVA")) return 4;
+            if (missile.Equals("DEVASTATOR")) return 5;
+            if (missile.Equals("TIMEBOMB")) return 6;
+            if (missile.Equals("VORTEX")) return 7;
+            else
+            {
+                uConsole.Log("<ERROR> |: (missileStringToInt) string missile had unexpected type: " + missile);
+                return -1;
+            }
+        }
+
+        public static int missileProjectileTypeToInt(ProjPrefab missile)
+        {
+            if (missile == ProjPrefab.missile_falcon) return 0;
+            if (missile == ProjPrefab.missile_pod) return 1;
+            if (missile == ProjPrefab.missile_hunter) return 2;
+            if (missile == ProjPrefab.missile_creeper) return 3;
+            if (missile == ProjPrefab.missile_smart) return 4;
+            if (missile == ProjPrefab.missile_devastator) return 5;
+            if (missile == ProjPrefab.missile_timebomb) return 6;
+            if (missile == ProjPrefab.missile_vortex) return 7;
+            else
+            {
+                uConsole.Log("||ERROR IN TRIGGER (helper) hasMissileAmmo(ProjPrefab missile) missile: " + missile);
+                return -1;
+            }
+        }
+
+        public static int missileTypeToInt(MissileType missile)
+        {
+            if (missile == MissileType.FALCON) return 0;
+            if (missile == MissileType.MISSILE_POD) return 1;
+            if (missile == MissileType.HUNTER) return 2;
+            if (missile == MissileType.CREEPER) return 3;
+            if (missile == MissileType.NOVA) return 4;
+            if (missile == MissileType.DEVASTATOR) return 5;
+            if (missile == MissileType.TIMEBOMB) return 6;
+            if (missile == MissileType.VORTEX) return 7;
+            else
+            {
+                uConsole.Log("||ERROR IN TRIGGER (helper) missileTypeToInt(MissileType missile) missile: " + missile);
+                return -1;
+            }
+        }
+
+        public static MissileType IntToMissileType(int missile)
+        {
+            if (missile == 0) return MissileType.FALCON;
+            if (missile == 1) return MissileType.MISSILE_POD;
+            if (missile == 2) return MissileType.HUNTER;
+            if (missile == 3) return MissileType.CREEPER;
+            if (missile == 4) return MissileType.NOVA;
+            if (missile == 5) return MissileType.DEVASTATOR;
+            if (missile == 6) return MissileType.TIMEBOMB;
+            if (missile == 7) return MissileType.VORTEX;
+            else
+            {
+                return MissileType.NUM;
+            }
+        }
+
+
+        [HarmonyPatch(typeof(Player), "UnlockWeaponClient")]
+        internal class WeaponPickup
+        {
+            public static void Postfix(WeaponType wt, bool silent, Player __instance)
+            {
+                if (MenuManager.opt_primary_autoswitch == 0 && MPAutoSelection.primarySwapFlag)
+                {
+                    if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
+                    {
+                        int new_weapon = getWeaponPriority(wt);
+                        int current_weapon = getWeaponPriority(GameManager.m_local_player.m_weapon_type);
+
+                        if (new_weapon < current_weapon && !PrimaryNeverSelect[new_weapon])
+                        {
+                            if (MPAutoSelection.COswapToHighest)
+                            {
+                                maybeSwapPrimary();
+                            }
+                            else
+                            {
+                                // this method doesnt need to check wether there is ammo or energy as weapon pickups always come with a small amount of it
+                                swapToWeapon(wt.ToString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+
+
+        [HarmonyPatch(typeof(Player), "RpcSetMissileAmmo")]
+        internal class SecondaryPickup
+        {
+            public static void Postfix(int missile_type, int ammo, Player __instance)
+            {
+                if (MenuManager.opt_primary_autoswitch == 0 && secondarySwapFlag)
+                {
+                    if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
+                    {
+
+                        if (areThereAllowedSecondaries())
+                        {
+                            int new_missile = getMissilePriority(IntToMissileType(missile_type));
+                            int current_missile = getMissilePriority(GameManager.m_local_player.m_missile_type);
+
+                            if (new_missile < current_missile && !SecondaryNeverSelect[new_missile])
+                            {
+                                if (COswapToHighest)
+                                {
+                                    maybeSwapMissiles();
+                                }
+                                else
+                                {
+                                    swapToMissile(missile_type);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+
+        // WORKS (1.3.8)
+        // last change: stopped prefix return false if the weapon couldnt get swapped because of an empty weapons array
+        [HarmonyPatch(typeof(Player), "SwitchToAmmoWeapon")]
+        internal class OutOfAmmo
+        {
+            private static bool Prefix(Player __instance)
+            {
+                if (MenuManager.opt_primary_autoswitch == 0 && MPAutoSelection.primarySwapFlag)
+                {
+                    if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
+                    {
+                        maybeSwapPrimary();
+                        if (swap_failed)
+                        {
+                            uConsole.Log("-AUTOORDER- [EB] swap failed on trying to switch to an ammo weapon");
+                            swap_failed = false;
+                            return true;
+                        }
+                        else
+                        {
+                            uConsole.Log(" - Denied Execution of original Method because swap failed (SwitchToAmmoWeapon)");
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                return true;
+            }
+        }
+
+        // WORKS (1.3.8)
+        // last change: stopped prefix return false if the weapon couldnt get swapped because of an empty weapons array
+        [HarmonyPatch(typeof(Player), "SwitchToEnergyWeapon")]
+        internal class OutOfEnergy
+        {
+            private static bool Prefix(Player __instance)
+            {
+                if (MenuManager.opt_primary_autoswitch == 0 && primarySwapFlag)
+                {
+                    if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
+                    {
+
+                        maybeSwapPrimary();
+                        if (swap_failed)
+                        {
+                            uConsole.Log("-AUTOORDER- [EB] swap failed on trying to switch to an energy weapon");
+                            swap_failed = false;
+                            return true;
+                        }
+                        else
+                        {
+                            uConsole.Log(" - Denied Execution of original Method because swap failed (SwitchToEnergyWeapon)");
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                return true;
+            }
+        }
+
+        // WORKS (1.6.1)
+        [HarmonyPatch(typeof(Player), "NextWeapon")]
+        internal class NextLastWeaponBasedOnPriority
+        {
+            public static bool Prefix(Player __instance, bool prev)
+            {
+
+                if (MenuManager.opt_primary_autoswitch == 0 && primarySwapFlag && patchPrevNext)
+                {
+                    if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
+                    {
+                        // find the highest primary, set networkm type to it and update the weapon name
+                        WeaponType cand = returnNextPrimary(__instance, prev);
+                        if (cand == WeaponType.NUM) return false;
+                        else
+                        {
+                            __instance.Networkm_weapon_type = cand;
+                            __instance.UpdateCurrentWeaponName();
+                            return false;
+                        }
+                    }
+
+                }
+                return true;
+            }
+        }
+
+
+        [HarmonyPatch(typeof(Player), "MaybeSwitchToNextMissile")]
+        internal class NextLastMissileBasedOnPriority
+        {
+            public static bool Prefix(Player __instance)
+            {
+
+                if (MenuManager.opt_primary_autoswitch == 0 && MPAutoSelection.secondarySwapFlag)
+                {
+                    if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
+                    {
+
+                        if (!__instance.CanFireMissileAmmo(MissileType.NUM))
+                        {
+
+                            DelayedSwitchTimer re = new DelayedSwitchTimer();
+                            re.Awake();
+
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+
+
+
+
+
+
+
+        // This class is used to initiate a delayed swap in order to not confuse get overwritten by a slow server control
+        internal class DelayedSwitchTimer
+        {
+            Timer timer;
+
+            public DelayedSwitchTimer(){}
+
+            public void Awake()
+            {
+                var ntimer = new Timer(250);
+                ntimer.Elapsed += new ElapsedEventHandler(timer_Elapsed);
+                ntimer.Enabled = true;
+                ntimer.AutoReset = false;
+                timer = ntimer;
+            }
+
+            private void timer_Elapsed(object sender, ElapsedEventArgs e)
+            {
+                int weapon_num = findHighestPrioritizedUseableMissile();
+
+                if (GameManager.m_local_player.m_missile_level[weapon_num] == WeaponUnlock.LOCKED || GameManager.m_local_player.m_missile_ammo[weapon_num] == 0)
+                {
+                    return;
+                }
+                if (GameManager.m_local_player.m_missile_type != (MissileType)weapon_num)
+                {
+                    GameManager.m_local_player.Networkm_missile_type = (MissileType)weapon_num;
+                    GameManager.m_local_player.CallCmdSetCurrentMissile(GameManager.m_local_player.m_missile_type);
+                    GameManager.m_local_player.UpdateCurrentMissileName();
+                }
+            }
+        }
+
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        //              VARIABLES (Switchlogic)                  
+        /////////////////////////////////////////////////////////////////////////////////////
+        public static String[] PrimaryPriorityArray = new String[8];
+        public static String[] SecondaryPriorityArray = new String[8];
+        public static bool[] PrimaryNeverSelect = new bool[8];
+        public static bool[] SecondaryNeverSelect = new bool[8];
+        public static string[] EnergyWeapons = { "IMPULSE", "CYCLONE", "REFLEX", "THUNDERBOLT", "LANCER", };
+        public static string[] AmmoWeapons = { "CRUSHER", "FLAK", "DRILLER" };
+
+        public static string textFile = Path.Combine(Application.persistentDataPath, "Weapon-Priority-List.txt");
+
+        public static bool swap_failed = false;
+
+
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        //              PUBLIC VARIABLES                  
+        /////////////////////////////////////////////////////////////////////////////////////
+        public static bool isCurrentlyInLobby = false;
+        public static bool isInitialised = false;
+
+        public static string last_valid_description = "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
+
+        public static string OptionFilePath = Path.Combine(Application.persistentDataPath, "WPS-ModOptions-File.txt"); //path to config file // not needed anymore, delete on sight
+
+        public static bool primarySwapFlag = true;   // toggles the whole primary selection logic
+        public static bool secondarySwapFlag = true; // toggles the whole secondary selection logic
+        public static bool COswapToHighest = false;  // toggles wether on pickup  the logic should switch to the highest weapon or the picked up weapon if its higher
+        public static bool patchPrevNext = false;    // toggles wether the default prev/next weapon swap methods should be replaced with a priority based prev/next
+        public static bool zorc = false;             // extra alert for old men when the devastator gets autoselected, still need to find an annoying sound for that
+        public static bool miasmic = false;          // dont draw certain hud elements
+
+    }
+}

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -13,7 +13,7 @@ namespace GameMod
 {
     class MPAutoSelection
     {
-
+        
         [HarmonyPatch(typeof(GameManager), "Start")]
         internal class CommandsAndInitialisationPatch
         {
@@ -21,12 +21,11 @@ namespace GameMod
             {
                 uConsole.RegisterCommand("toggleprimaryorder", "toggles all Weapon Selection logic related to primary weapons", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdTogglePrimary)); 
                 uConsole.RegisterCommand("togglesecondaryorder", "toggles all Weapon Selection logic related to secondary weapons", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdToggleSecondary)); 
-                uConsole.RegisterCommand("toggle_hud", "Toggles some HUD elements", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdToggleHud)); 
+                uConsole.RegisterCommand("toggle_hud", "Toggles some HUD elements", new uConsole.DebugCommand(CommandsAndInitialisationPatch.CmdToggleHud));
 
                 Initialise();
-		if( primarySwapFlag || secondarySwapFlag ) {
-                    MenuManager.opt_primary_autoswitch = 0;
-                }
+
+
             }
 
             // COMMANDS
@@ -34,19 +33,20 @@ namespace GameMod
             {
                 miasmic = !miasmic;
                 uConsole.Log("Toggled HUD! current state : " + miasmic);
+                MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
             }
 
             private static void CmdTogglePrimary()
             {
                 primarySwapFlag = !primarySwapFlag;
-                uConsole.Log("[AO] Primary weapon swapping: " + primarySwapFlag);
+                uConsole.Log("[WPS] Primary weapon swapping: " + primarySwapFlag);
                 MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
             }
 
             private static void CmdToggleSecondary()
             {
                 secondarySwapFlag = !secondarySwapFlag;
-                uConsole.Log("[AO] Secondary weapon swapping: " + secondarySwapFlag);
+                uConsole.Log("[WPS] Secondary weapon swapping: " + secondarySwapFlag);
                 MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
             }
         }
@@ -106,10 +106,6 @@ namespace GameMod
                 isCurrentlyInLobby = false;
             }
         }
-
-
-
-
 
 
 
@@ -176,6 +172,7 @@ namespace GameMod
                 sw.WriteLine(patchPrevNext);
                 sw.WriteLine(zorc);
                 sw.WriteLine(miasmic);
+                sw.Close();
             }
         }
 
@@ -276,7 +273,7 @@ namespace GameMod
                     }
                     else if (counter == 35)
                     {
-                        if (ln == "True" || ln == "False")  patchPrevNext = stringToBool(ln); 
+                        if (ln == "True" || ln == "False")  patchPrevNext = stringToBool(ln);
                     }
                     else if (counter == 36)
                     {
@@ -944,9 +941,10 @@ namespace GameMod
         [HarmonyPatch(typeof(Player), "UnlockWeaponClient")]
         internal class WeaponPickup
         {
-            public static void Postfix(WeaponType wt, Player __instance)
+            public static bool Prefix(WeaponType wt, Player __instance)
             {
-                if (MenuManager.opt_primary_autoswitch == 0 && MPAutoSelection.primarySwapFlag)
+
+                if (primarySwapFlag)
                 {
                     if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
                     {
@@ -955,17 +953,28 @@ namespace GameMod
 
                         if (new_weapon < current_weapon && !PrimaryNeverSelect[new_weapon])
                         {
-                            if (MPAutoSelection.COswapToHighest)
+                            if (!Controls.IsPressed(CCInput.FIRE_WEAPON))
                             {
-                                maybeSwapPrimary();
+                                if (MPAutoSelection.COswapToHighest)
+                                {
+                                    maybeSwapPrimary();
+                                }
+                                else
+                                {
+                                    swapToWeapon(wt.ToString());
+                                }
                             }
                             else
                             {
-                                // this method doesnt need to check wether there is ammo or energy as weapon pickups always come with a small amount of it
-                                swapToWeapon(wt.ToString());
+                                waitingSwapWeaponType = MPAutoSelection.COswapToHighest ? "NUM" : wt.ToString();
                             }
                         }
                     }
+                    return false;
+                }
+                else
+                {
+                    return true;
                 }
             }
         }
@@ -978,7 +987,8 @@ namespace GameMod
         {
             public static void Postfix(int missile_type, Player __instance)
             {
-                if (MenuManager.opt_primary_autoswitch == 0 && secondarySwapFlag)
+
+                if (secondarySwapFlag)
                 {
                     if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
                     {
@@ -1014,7 +1024,8 @@ namespace GameMod
         {
             private static bool Prefix(Player __instance)
             {
-                if (MenuManager.opt_primary_autoswitch == 0 && MPAutoSelection.primarySwapFlag)
+
+                if (primarySwapFlag)
                 {
                     if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
                     {
@@ -1044,7 +1055,8 @@ namespace GameMod
         {
             private static bool Prefix(Player __instance)
             {
-                if (MenuManager.opt_primary_autoswitch == 0 && primarySwapFlag)
+
+                if (primarySwapFlag)
                 {
                     if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
                     {
@@ -1075,7 +1087,7 @@ namespace GameMod
             public static bool Prefix(Player __instance, bool prev)
             {
 
-                if (MenuManager.opt_primary_autoswitch == 0 && primarySwapFlag && patchPrevNext)
+                if (primarySwapFlag && patchPrevNext)
                 {
                     if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
                     {
@@ -1102,7 +1114,7 @@ namespace GameMod
             public static bool Prefix(Player __instance)
             {
 
-                if (MenuManager.opt_primary_autoswitch == 0 && MPAutoSelection.secondarySwapFlag)
+                if (secondarySwapFlag)
                 {
                     if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && __instance == GameManager.m_local_player)
                     {
@@ -1122,9 +1134,34 @@ namespace GameMod
 
 
 
+        // checks wether there was a swap that didnt get completed due to the player firing
+        [HarmonyPatch(typeof(GameManager), "Update")]
+        internal class ProcessDelayedSwap
+        {
+            public static void Postfix()
+            {
 
+                if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay())
+                {
+                    if (!Controls.IsPressed(CCInput.FIRE_WEAPON) && !waitingSwapWeaponType.Equals("") )
+                    {
+                        if (waitingSwapWeaponType.Equals("NUM"))
+                        {
+                            maybeSwapPrimary();
+                        }
+                        else
+                        {
+                            swapToWeapon(waitingSwapWeaponType);
+                        }
+                        GameManager.m_local_player.UpdateCurrentWeaponName();
+                        waitingSwapWeaponType = "";
+                    }
+                }
 
+            }
+        }
 
+        
 
 
         // This class is used to initiate a delayed swap in order to not get overwritten by a slow server control
@@ -1166,33 +1203,34 @@ namespace GameMod
         /////////////////////////////////////////////////////////////////////////////////////
         //              VARIABLES (Switchlogic)                  
         /////////////////////////////////////////////////////////////////////////////////////
-        public static String[] PrimaryPriorityArray = new String[8];
-        public static String[] SecondaryPriorityArray = new String[8];
-        public static bool[] PrimaryNeverSelect = new bool[8];
-        public static bool[] SecondaryNeverSelect = new bool[8];
+        public static String[] PrimaryPriorityArray = new String[8];   // holds the current primary priorities with 0 being the highest
+        public static String[] SecondaryPriorityArray = new String[8]; // holds the current secondary priorities with 0 being the highest
+        public static bool[] PrimaryNeverSelect = new bool[8];         // parallel to the primary priorities
+        public static bool[] SecondaryNeverSelect = new bool[8];       // parallel to the secondary priorities
         public static string[] EnergyWeapons = { "IMPULSE", "CYCLONE", "REFLEX", "THUNDERBOLT", "LANCER" };
         public static string[] AmmoWeapons = { "CRUSHER", "FLAK", "DRILLER" };
 
         public static bool swap_failed = false;
 
+        private static string waitingSwapWeaponType = ""; // used to hold the weapon type value if a swap gets put on hold due to the player still firing
 
 
 
-
-        /////////////////////////////////////////////////////////////////////////////////////
-        //              PUBLIC VARIABLES                  
-        /////////////////////////////////////////////////////////////////////////////////////
+        /////////////////////////////////////////////
+        //            PUBLIC VARIABLES             //                                  
+        /////////////////////////////////////////////
         public static bool isCurrentlyInLobby = false;
         public static bool isInitialised = false;
 
         public static string last_valid_description = "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
 
-        public static bool primarySwapFlag = true;   // toggles the whole primary selection logic
-        public static bool secondarySwapFlag = true; // toggles the whole secondary selection logic
-        public static bool COswapToHighest = false;  // toggles wether on pickup  the logic should switch to the highest weapon or the picked up weapon if its higher
-        public static bool patchPrevNext = false;    // toggles wether the default prev/next weapon swap methods should be replaced with a priority based prev/next
-        public static bool zorc = false;             // extra alert for old men when the devastator gets autoselected, still need to find an annoying sound for that
-        public static bool miasmic = false;          // dont draw certain hud elements
+        public static bool primarySwapFlag = true;      // toggles the whole primary selection logic
+        public static bool secondarySwapFlag = true;    // toggles the whole secondary selection logic
+        public static bool COswapToHighest = false;     // toggles wether on pickup  the logic should switch to the highest weapon or the picked up weapon if its higher
+        public static bool patchPrevNext = false;       // toggles wether the default prev/next weapon swap methods should be replaced with a priority based prev/next
+        public static bool zorc = false;                // extra alert for old men when the devastator gets autoselected, still need to find an annoying sound for that
+        public static bool miasmic = false;             // dont draw certain hud elements
+        public static bool allowSwapWhileFiring = true; // toggles wether weapon swaps are allowed to happen while the player is firing, if set to false it will delay the swap till the player is not firing anymore                                           
 
         public static string textFile = Path.Combine(Application.persistentDataPath, "AutoSelect-Config.txt");
     }

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using System.Timers;
 using UnityEngine;
 
-namespace mod_WeaponSelection
+namespace GameMod
 {
     class MPAutoSelection
     {

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -42,14 +42,14 @@ namespace GameMod
             private static void CmdTogglePrimary()
             {
                 primarySwapFlag = !primarySwapFlag;
-                uConsole.Log("[WPS] Primary weapon swapping: " + primarySwapFlag);
+                uConsole.Log("[AO] Primary weapon swapping: " + primarySwapFlag);
                 MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
             }
 
             private static void CmdToggleSecondary()
             {
                 secondarySwapFlag = !secondarySwapFlag;
-                uConsole.Log("[WPS] Secondary weapon swapping: " + secondarySwapFlag);
+                uConsole.Log("[AO] Secondary weapon swapping: " + secondarySwapFlag);
                 MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
             }
         }
@@ -292,7 +292,6 @@ namespace GameMod
                     counter++;
                 }
                 file.Close();
-
             }
         }
 
@@ -1198,6 +1197,6 @@ namespace GameMod
         public static bool zorc = false;             // extra alert for old men when the devastator gets autoselected, still need to find an annoying sound for that
         public static bool miasmic = false;          // dont draw certain hud elements
 
-        public static string textFile = Path.Combine(Application.persistentDataPath, "Weapon-Priority-List.txt");
+        public static string textFile = Path.Combine(Application.persistentDataPath, "AutoSelect-Config.txt");
     }
 }

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -21,18 +21,54 @@ namespace GameMod
             public static int loadout1LastTick;
             public static int loadout2LastTick;
 
+            private static int last_menu_micro_state = 0;
+            public static void Prefix()
+            {
+                last_menu_micro_state = MenuManager.m_menu_micro_state;
+            }
             public static void Postfix()
             {
+                MenuManager.m_menu_micro_state = last_menu_micro_state;
+
                 selected = DrawMpAutoselectOrderingScreen.returnPrimarySelected();
                 selected2 = DrawMpAutoselectOrderingScreen.returnSecondarySelected();
+
+                switch (UIManager.m_menu_selection)
+                {
+                    case 200:
+                    case 201:
+                    case 202:
+                    case 203:
+                        if (UIManager.PushedSelect(100))
+                        {
+                            MenuManager.m_menu_micro_state = UIManager.m_menu_selection - 200;
+                            MenuManager.UIPulse(1f);
+                            GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                        }
+                        break;
+                }
+
                 switch (MenuManager.m_menu_sub_state)
                 {
                     case MenuSubState.ACTIVE:
+                        if (Controls.JustPressed(CCInput.MENU_PGUP) || (UIManager.PushedSelect(-1) && UIManager.m_menu_selection == 198))
+                        {
+                            MenuManager.m_menu_micro_state = (MenuManager.m_menu_micro_state + 3) % 4;
+                            MenuManager.UIPulse(1f);
+                            GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                        }
+                        else if (Controls.JustPressed(CCInput.MENU_PGDN) || (UIManager.PushedSelect(-1) && UIManager.m_menu_selection == 199))
+                        {
+                            MenuManager.m_menu_micro_state = (MenuManager.m_menu_micro_state + 1) % 4;
+                            MenuManager.UIPulse(1f);
+                            GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                        }
                         if (MenuManager.m_menu_micro_state == 3)
                         {
                             switch (UIManager.m_menu_selection)
                             {
-                                case 200:
+                                /*
+                                case 200: 
                                 case 201:
                                 case 202:
                                 case 203:
@@ -42,7 +78,7 @@ namespace GameMod
                                         MenuManager.UIPulse(1f);
                                         GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                                     }
-                                    break;
+                                    break;*/
                                 case 1720:
                                     if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(0);
                                     break;
@@ -153,6 +189,7 @@ namespace GameMod
                                         {
                                             MPAutoSelection.primarySwapFlag = true;
                                             MPAutoSelection.secondarySwapFlag = true;
+                                            MenuManager.opt_primary_autoswitch = 0;
                                             SFXCueManager.PlayCue2D(SFXCue.enemy_detonatorB_alert, 0.8f, 0f, 0f, false);
                                             // SFXCueManager.PlayRawSoundEffect2D(SoundEffect.door_open2, 1f, -0.2f, 0.25f, false);
                                         }
@@ -160,6 +197,7 @@ namespace GameMod
                                     }
                                     break;
                                 case 2101: //REPLACE
+                                    /*
                                     if (UIManager.PushedSelect(100))
                                     {
                                         if (MPAutoSelection.patchPrevNext)
@@ -173,7 +211,7 @@ namespace GameMod
                                             SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                                         }
                                         DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
+                                    }*/
                                     break;
                                 case 2102:
                                     if (UIManager.PushedSelect(100))
@@ -186,6 +224,7 @@ namespace GameMod
                                         else
                                         {
                                             MPAutoSelection.secondarySwapFlag = true;
+                                            MenuManager.opt_primary_autoswitch = 0;
                                             SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                                         }
                                         DrawMpAutoselectOrderingScreen.saveToFile();
@@ -202,12 +241,13 @@ namespace GameMod
                                         else
                                         {
                                             MPAutoSelection.primarySwapFlag = true;
+                                            MenuManager.opt_primary_autoswitch = 0;
                                             SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                                         }
                                         DrawMpAutoselectOrderingScreen.saveToFile();
                                     }
                                     break;
-                                case 2104: //
+                                case 2104: 
                                     if (UIManager.PushedSelect(100))
                                     {
                                         if (MPAutoSelection.zorc)
@@ -223,7 +263,7 @@ namespace GameMod
                                         DrawMpAutoselectOrderingScreen.saveToFile();
                                     }
                                     break;
-                                case 2105: //
+                                case 2105: 
                                     if (UIManager.PushedSelect(100))
                                     {
                                         if (MPAutoSelection.COswapToHighest)
@@ -266,7 +306,6 @@ namespace GameMod
                         }
                         else
                         {
-                            //uConsole.Log("NOT 203 "+Player.Mp_loadout1 + " : " + Player.Mp_loadout2);
                             if (Player.Mp_loadout1 == 203 || Player.Mp_loadout2 == 203)
                             {
                                 Player.Mp_loadout1 = loadout1LastTick;
@@ -279,16 +318,12 @@ namespace GameMod
                             }
                             if (UIManager.PushedSelect(100) && UIManager.m_menu_selection == 203)
                             {
-                                //MenuManager.SetDefaultSelection(-1);
                                 MenuManager.m_menu_micro_state = 3;
                                 MenuManager.UIPulse(1f);
                                 GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                             }
 
                         }
-
-
-
                         break;
                 }
             }
@@ -359,7 +394,6 @@ namespace GameMod
 
 
         // Adds the Auto order entry in the customize menu
-        // Todo: fix the iteration to account for the new element
         [HarmonyPatch(typeof(UIElement), "DrawMpTabs")]
         internal class AddFourthTab
         {
@@ -399,6 +433,19 @@ namespace GameMod
         }
 
 
+        [HarmonyPatch(typeof(MenuManager), "ControlsOptionsUpdate")]
+        internal class TrackNeverSelectStatus
+        {
+            public static void Postfix()
+            {
+                if(  MenuManager.opt_primary_autoswitch != 0 && (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag) )
+                {
+                    MPAutoSelection.primarySwapFlag = false;
+                    MPAutoSelection.secondarySwapFlag = false;
+                }
+            }
+        }
+        
 
 
 
@@ -406,8 +453,6 @@ namespace GameMod
         [HarmonyPatch(typeof(UIElement), "DrawMpCustomize")]
         internal class DrawMpAutoselectOrderingScreen
         {
-            static string[] PrimaryPriorityArray = new string[8];
-            static string[] SecondaryPriorityArray = new string[8];
 
             static void Postfix(UIElement __instance)
             {
@@ -417,7 +462,6 @@ namespace GameMod
                     Initialise();
                     isInitialised = true; //should be set to false when leaving the MpCustomize Menu
                 }
-
                 int menu_micro_state = MenuManager.m_menu_micro_state;
                 if (menu_micro_state == 3)
                 {
@@ -428,49 +472,14 @@ namespace GameMod
 
             public static void Initialise()
             {
-                Primary[0] = MPAutoSelection.PrimaryPriorityArray[0];
-                Primary[1] = MPAutoSelection.PrimaryPriorityArray[1];
-                Primary[2] = MPAutoSelection.PrimaryPriorityArray[2];
-                Primary[3] = MPAutoSelection.PrimaryPriorityArray[3];
-                Primary[4] = MPAutoSelection.PrimaryPriorityArray[4];
-                Primary[5] = MPAutoSelection.PrimaryPriorityArray[5];
-                Primary[6] = MPAutoSelection.PrimaryPriorityArray[6];
-                Primary[7] = MPAutoSelection.PrimaryPriorityArray[7];
-
-                Secondary[0] = MPAutoSelection.SecondaryPriorityArray[0];
-                Secondary[1] = MPAutoSelection.SecondaryPriorityArray[1];
-                Secondary[2] = MPAutoSelection.SecondaryPriorityArray[2];
-                Secondary[3] = MPAutoSelection.SecondaryPriorityArray[3];
-                Secondary[4] = MPAutoSelection.SecondaryPriorityArray[4];
-                Secondary[5] = MPAutoSelection.SecondaryPriorityArray[5];
-                Secondary[6] = MPAutoSelection.SecondaryPriorityArray[6];
-                Secondary[7] = MPAutoSelection.SecondaryPriorityArray[7];
+                for (int i = 0; i < 8; i++)
+                {
+                    Primary[i] = MPAutoSelection.PrimaryPriorityArray[i];
+                    Secondary[i] = MPAutoSelection.SecondaryPriorityArray[i];
+                }
             }
 
-            public static bool isInitialised = false;
-
-            public static string[] Primary = {
-                MPAutoSelection.PrimaryPriorityArray[0],
-                MPAutoSelection.PrimaryPriorityArray[1],
-                MPAutoSelection.PrimaryPriorityArray[2],
-                MPAutoSelection.PrimaryPriorityArray[3],
-                MPAutoSelection.PrimaryPriorityArray[4],
-                MPAutoSelection.PrimaryPriorityArray[5],
-                MPAutoSelection.PrimaryPriorityArray[6],
-                MPAutoSelection.PrimaryPriorityArray[7],
-            };
-            public static string[] Secondary = {
-                MPAutoSelection.SecondaryPriorityArray[0],
-                MPAutoSelection.SecondaryPriorityArray[1],
-                MPAutoSelection.SecondaryPriorityArray[2],
-                MPAutoSelection.SecondaryPriorityArray[3],
-                MPAutoSelection.SecondaryPriorityArray[4],
-                MPAutoSelection.SecondaryPriorityArray[5],
-                MPAutoSelection.SecondaryPriorityArray[6],
-                MPAutoSelection.SecondaryPriorityArray[7]
-            };
-            public static bool[] isPrimarySelected = new bool[8];
-            public static bool[] isSecondarySelected = new bool[8];
+           
 
             public static int returnPrimarySelected()
             {
@@ -498,6 +507,7 @@ namespace GameMod
                 return counter;
             }
 
+
             public static void SwapSelectedPrimary()
             {
                 int counter = 0;
@@ -520,8 +530,9 @@ namespace GameMod
 
                 isPrimarySelected[selection[0]] = false;
                 isPrimarySelected[selection[1]] = false;
-                MPAutoSelection.PrimaryNeverSelect[selection[0]] = false;
-                MPAutoSelection.PrimaryNeverSelect[selection[1]] = false;
+                bool tmp = MPAutoSelection.PrimaryNeverSelect[selection[0]];
+                MPAutoSelection.PrimaryNeverSelect[selection[0]] = MPAutoSelection.PrimaryNeverSelect[selection[1]];
+                MPAutoSelection.PrimaryNeverSelect[selection[1]] = tmp;
 
                 saveToFile();
                 MPAutoSelection.Initialise();
@@ -549,8 +560,9 @@ namespace GameMod
 
                 isSecondarySelected[selection[0]] = false;
                 isSecondarySelected[selection[1]] = false;
-                MPAutoSelection.SecondaryNeverSelect[selection[0]] = false;
-                MPAutoSelection.SecondaryNeverSelect[selection[1]] = false;
+                bool tmp = MPAutoSelection.SecondaryNeverSelect[selection[0]];
+                MPAutoSelection.SecondaryNeverSelect[selection[0]] = MPAutoSelection.SecondaryNeverSelect[selection[1]];
+                MPAutoSelection.SecondaryNeverSelect[selection[1]] = tmp;
 
                 saveToFile();
                 MPAutoSelection.Initialise();
@@ -603,40 +615,14 @@ namespace GameMod
 
             public static string selectionToDescription(int n)
             {
-                if (n == 2100)
-                {
-                    return "TOGGLES WETHER THE WHOLE FMOD SHOULD BE ACTIVE";
-                }
-                if (n == 2101)
-                {
-                    return "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
-                }
-                if (n <= 2017 && n >= 2000)
-                {
-                    return "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
-                }
-                if (n <= 1735 && n >= 1720)
-                {
-                    return "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
-                }
-                if (n == 2103)
-                {
-                    return "TOGGLES EVERYTHING RELATED TO PRIMARY WEAPONS IN THIS MOD";
-                }
-                if (n == 2102)
-                {
-                    return "TOGGLES EVERYTHING RELATED TO SECONDARY WEAPONS IN THIS MOD";
-                }
-                if (n == 2104)
-                {
-                    // Alert
-                    return "DISPLAY A WARNING IF A DEVASTATOR GETS AUTOSELECTED";
-                }
-                if (n == 2105)
-                {
-                    // On Swap
-                    return "SETS WETHER ON PICKUP SHOULD SWAP TO THE PICKED UP (IF VALID) OR THE HIGHEST";
-                }
+                if (n == 2100) return "TOGGLES WETHER THE WHOLE MOD SHOULD BE ACTIVE";
+                if (n == 2101) return "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
+                if (n <= 2017 && n >= 2000) return "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
+                if (n <= 1735 && n >= 1720) return "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
+                if (n == 2103) return "TOGGLES EVERYTHING RELATED TO PRIMARY WEAPONS IN THIS MOD";
+                if (n == 2102) return "TOGGLES EVERYTHING RELATED TO SECONDARY WEAPONS IN THIS MOD";
+                if (n == 2104) return "DISPLAY A WARNING IF A DEVASTATOR GETS AUTOSELECTED";
+                if (n == 2105) return "SETS WETHER ON PICKUP SHOULD SWAP TO THE PICKED UP (IF VALID) OR THE HIGHEST";
                 else
                 {
                     return MPAutoSelection.last_valid_description;
@@ -655,7 +641,7 @@ namespace GameMod
                 if (weapon.Equals("LANCER") || weapon.Equals("VORTEX")) return 7;
                 else
                 {
-                    uConsole.Log("-AUTOORDERSELECT- [ERROR] getWeaponIconIndex didnt recognise the given weapon string");
+                    uConsole.Log("-AUTOSELECT- [ERROR] getWeaponIconIndex didnt recognise the given weapon string");
                     return 0;
                 }
             }
@@ -666,156 +652,111 @@ namespace GameMod
                 UIManager.X_SCALE = 0.2f;
                 UIManager.ui_bg_dark = true;
                 uie.DrawMenuBG();
-                Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
 
+                Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
                 position.y += 164f;
                 Vector2 position2 = position;
-
                 position.x -= 160f;
                 position2.x += 160f;
-                Vector2 temp_pos = position;
 
-                Color ceas = UIManager.m_col_ui4;
+                UIColorPrimaries = MPAutoSelection.primarySwapFlag ? UIManager.m_col_ui4 : UIManager.m_col_ui0;
+                UIColorSecondaries = MPAutoSelection.secondarySwapFlag ? UIManager.m_col_ui4 : UIManager.m_col_ub0;
 
                 Vector2 left = position;
                 Vector2 right = position;
                 left.x += 75;
                 right.x += 240;
 
-                //Draws the weapon / neverselect buttons
+                //Draw the neverselect Buttons
                 for (int i = 0; i < 8; i++)
                 {
-
-                    int primaryindex = getWeaponIconIndex(MPAutoSelection.PrimaryPriorityArray[i]); //temporary
+                    int primaryindex = getWeaponIconIndex(MPAutoSelection.PrimaryPriorityArray[i]);
                     int secondaryindex = getWeaponIconIndex(MPAutoSelection.SecondaryPriorityArray[i]);
-                    UIManager.DrawSpriteUI(left, 0.15f, 0.15f, ceas, uie.m_alpha, 26 + primaryindex);
-
-                    UIManager.DrawSpriteUI(right, 0.15f, 0.15f, ceas, uie.m_alpha, 104 + secondaryindex);
+                    UIManager.DrawSpriteUI(left, 0.15f, 0.15f, UIColorPrimaries, uie.m_alpha, 26 + primaryindex);
+                    UIManager.DrawSpriteUI(right, 0.15f, 0.15f, UIColorSecondaries, uie.m_alpha, 104 + secondaryindex);
 
                     left.y += 50;
                     right.y += 50;
-
-                    if (MPAutoSelection.PrimaryNeverSelect[i]) // irgendwas mit i
+                    if (MPAutoSelection.PrimaryNeverSelect[i])
                     {
                         uie.DrawWideBox(position, 100f, 28f, Color.red, 0.2f, 7);
                         UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.red, 12);
                     }
                     position.x -= 150f;
-                    string s = "";
-                    if (!MPAutoSelection.PrimaryNeverSelect[i])
-                    {
-                        s += "+";
-                    }
-                    else
-                    {
-                        s += "-";
-                    }
-
-
-                    uie.SelectAndDrawItem(s, position, 2000 + i, false, 0.022f, 1f);
+                    uie.SelectAndDrawItem((!MPAutoSelection.PrimaryNeverSelect[i] ? "+" : "-"), position, 2000 + i, false, 0.022f, 1f);
                     position.x += 150f;
                     uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);
                     position.y += 50;
+
+
                     if (MPAutoSelection.SecondaryNeverSelect[i])
                     {
                         uie.DrawWideBox(position2, 100f, 28f, Color.red, 0.2f, 7);
                         UIManager.DrawQuadBarHorizontal(position2, 100f, 18f, 30, Color.red, 12);
                     }
                     position2.x += 150f;
-                    string a = "";
-                    if (!MPAutoSelection.SecondaryNeverSelect[i])
-                    {
-                        a += "+";
-                    }
-                    else
-                    {
-                        a += "-";
-                    }
-                    uie.SelectAndDrawItem(a, position2, 2010 + i, false, 0.022f, 1f);
+                    uie.SelectAndDrawItem((!MPAutoSelection.SecondaryNeverSelect[i] ? "+" : "-"), position2, 2010 + i, false, 0.022f, 1f);
                     position2.x -= 150f;
                     uie.SelectAndDrawHalfItem(Secondary[i], position2, 1728 + i, false);
                     position2.y += 50;
                 }
 
+
+                // other Buttons
                 position = Vector2.up * (UIManager.UI_TOP + 70f);
                 position.y += 164f;
                 position.x += 540f;
-                string mod = "";
-                string mod1 = "";
-                string mod2 = "";
-                if (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag)
-                {
-                    mod += "ACTIVE";
-                }
-                else
-                {
-                    mod += "INACTIVE";
-                }
-                if (MPAutoSelection.primarySwapFlag)
-                {
-                    mod1 += "ON";
-                }
-                else if (!MPAutoSelection.primarySwapFlag)
-                {
-                    mod1 += "OFF";
-                }
-                if (MPAutoSelection.secondarySwapFlag)
-                {
-                    mod2 += "ON";
-                }
-                else if (!MPAutoSelection.secondarySwapFlag)
-                {
-                    mod2 += "OFF";
-                }
-
-
-                uie.SelectAndDrawItem("Mod: " + mod, position, 2100, false, 0.3f, 0.45f);
-                position.y += 2f;
-                Vector2 cust;
-                cust.x = 542;
-                cust.y = 123;
-
-                /*
-                MPWeaponAutoSelection.drag.x = position.x;//UIManager.m_mouse_pos.x;
-                MPWeaponAutoSelection.drag.y = UIManager.m_mouse_pos.y;
-                uConsole.Log("x:" + UIManager.m_mouse_pos.x + "| y:" + UIManager.m_mouse_pos.y);*/
-
-
-                cust.x = 540;
-                cust.y = -123;
-                //UIManager.DrawQuadUIInner(cust, 97f, 1f, UIManager.m_col_ui2, 0.6f, 11, 0.75f);
-
-                position.y += 50f;
+                uie.SelectAndDrawItem("Status: " + ((MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag) ? "ACTIVE" : "INACTIVE"), position, 2100, false, 0.3f, 0.45f);
+                position.y += 52f;
                 position.x += 5f;
-                uie.SelectAndDrawItem("Weapon Logic: " + mod1, position, 2103, false, 0.27f, 0.4f);
+                uie.SelectAndDrawItem("Weapon Logic: " + (MPAutoSelection.primarySwapFlag ? "ON" : "OFF"), position, 2103, false, 0.27f, 0.4f);
                 position.y += 50f;
-                uie.SelectAndDrawItem("Missile Logic: " + mod2, position, 2102, false, 0.27f, 0.4f);
-                cust.x = 540;
-                cust.y = -22;
-                //UIManager.DrawQuadUIInner(cust, 97f, 1f, UIManager.m_col_ui2, 0.6f, 11, 0.75f);
-                // 2101 is reserved for patch prev/next logic
+                uie.SelectAndDrawItem("Missile Logic: " + (MPAutoSelection.secondarySwapFlag ? "ON" : "OFF"), position, 2102, false, 0.27f, 0.4f);
 
-                string a1 = MPAutoSelection.patchPrevNext ? "ON" : "OFF";
-                string b = MPAutoSelection.zorc ? "ON" : "OFF";
-                string c = MPAutoSelection.COswapToHighest ? "HIGHEST" : "PICKUP";
 
                 position.x -= 5f;
-                position.y += 132; //original 147
-                //var MPWeaponAutoSelection.patchPrevNext
-                uie.SelectAndDrawItem("REPLACE: " + a1, position, 2101, false, 0.3f, 0.45f); // Possible Options: DEFAULT/PRIORITY
+                position.y += 182;
+                uie.SelectAndDrawItem("ALERT: " + (MPAutoSelection.zorc ? "ON" : "OFF"), position, 2104, false, 0.3f, 0.45f);
                 position.y += 50;
-                //var MPWeaponAutoSelection.zorc
-                uie.SelectAndDrawItem("ALERT: " + b, position, 2104, false, 0.3f, 0.45f); // Possible Options: OFF/ON
-                position.y += 50;
-                uie.SelectAndDrawItem("SWAP TO: " + c, position, 2105, false, 0.3f, 0.45f); // Possible Options: DEFAULT/PRIORITY
+                uie.SelectAndDrawItem("SWAP TO: " + (MPAutoSelection.COswapToHighest ? "HIGHEST" : "PICKUP"), position, 2105, false, 0.3f, 0.45f);
 
-                //this adds a short description of what the button that is currently selected does if its pressed
+
+
+                // Button description 
                 position2.x -= 160f;
                 position2.y -= 14f;
                 string k = selectionToDescription(UIManager.m_menu_selection);
                 MPAutoSelection.last_valid_description = k;
                 uie.DrawLabelSmall(position2, k, 500f);
             }
+
+            public static bool isInitialised = false;
+
+            public static string[] Primary = {
+                MPAutoSelection.PrimaryPriorityArray[0],
+                MPAutoSelection.PrimaryPriorityArray[1],
+                MPAutoSelection.PrimaryPriorityArray[2],
+                MPAutoSelection.PrimaryPriorityArray[3],
+                MPAutoSelection.PrimaryPriorityArray[4],
+                MPAutoSelection.PrimaryPriorityArray[5],
+                MPAutoSelection.PrimaryPriorityArray[6],
+                MPAutoSelection.PrimaryPriorityArray[7],
+            };
+            public static string[] Secondary = {
+                MPAutoSelection.SecondaryPriorityArray[0],
+                MPAutoSelection.SecondaryPriorityArray[1],
+                MPAutoSelection.SecondaryPriorityArray[2],
+                MPAutoSelection.SecondaryPriorityArray[3],
+                MPAutoSelection.SecondaryPriorityArray[4],
+                MPAutoSelection.SecondaryPriorityArray[5],
+                MPAutoSelection.SecondaryPriorityArray[6],
+                MPAutoSelection.SecondaryPriorityArray[7]
+            };
+            public static bool[] isPrimarySelected = new bool[8];
+            public static bool[] isSecondarySelected = new bool[8];
+
+            private static Color UIColorPrimaries;
+            private static Color UIColorSecondaries;
         }
 
 

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -25,6 +25,11 @@ namespace GameMod
             public static void Prefix()
             {
                 last_menu_micro_state = MenuManager.m_menu_micro_state;
+                if (!init)
+                {
+                    init = true;
+                    MenuManager.opt_primary_autoswitch = 0;
+                }
             }
             public static void Postfix()
             {
@@ -189,14 +194,13 @@ namespace GameMod
                                         {
                                             MPAutoSelection.primarySwapFlag = true;
                                             MPAutoSelection.secondarySwapFlag = true;
-                                            MenuManager.opt_primary_autoswitch = 0;
                                             SFXCueManager.PlayCue2D(SFXCue.enemy_detonatorB_alert, 0.8f, 0f, 0f, false);
                                             // SFXCueManager.PlayRawSoundEffect2D(SoundEffect.door_open2, 1f, -0.2f, 0.25f, false);
                                         }
                                         DrawMpAutoselectOrderingScreen.saveToFile();
                                     }
                                     break;
-                                case 2101: //REPLACE
+                                case 2101:
                                     /*
                                     if (UIManager.PushedSelect(100))
                                     {
@@ -224,7 +228,7 @@ namespace GameMod
                                         else
                                         {
                                             MPAutoSelection.secondarySwapFlag = true;
-                                            MenuManager.opt_primary_autoswitch = 0;
+                                            //MenuManager.opt_primary_autoswitch = 0;
                                             SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                                         }
                                         DrawMpAutoselectOrderingScreen.saveToFile();
@@ -241,7 +245,7 @@ namespace GameMod
                                         else
                                         {
                                             MPAutoSelection.primarySwapFlag = true;
-                                            MenuManager.opt_primary_autoswitch = 0;
+                                            //MenuManager.opt_primary_autoswitch = 0;
                                             SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                                         }
                                         DrawMpAutoselectOrderingScreen.saveToFile();
@@ -433,21 +437,6 @@ namespace GameMod
         }
 
 
-        [HarmonyPatch(typeof(MenuManager), "ControlsOptionsUpdate")]
-        internal class TrackNeverSelectStatus
-        {
-            public static void Postfix()
-            {
-                if(  MenuManager.opt_primary_autoswitch != 0 && (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag) )
-                {
-                    MPAutoSelection.primarySwapFlag = false;
-                    MPAutoSelection.secondarySwapFlag = false;
-                }
-            }
-        }
-        
-
-
 
 
         [HarmonyPatch(typeof(UIElement), "DrawMpCustomize")]
@@ -456,7 +445,6 @@ namespace GameMod
 
             static void Postfix(UIElement __instance)
             {
-                //Initialise();
                 if (isInitialised == false)
                 {
                     Initialise();
@@ -610,6 +598,7 @@ namespace GameMod
                     sw.WriteLine(MPAutoSelection.patchPrevNext);
                     sw.WriteLine(MPAutoSelection.zorc);
                     sw.WriteLine(MPAutoSelection.miasmic);
+                    sw.Close();
                 }
             }
 
@@ -649,6 +638,7 @@ namespace GameMod
 
             public static void DrawPriorityList(UIElement uie)
             {
+
                 UIManager.X_SCALE = 0.2f;
                 UIManager.ui_bg_dark = true;
                 uie.DrawMenuBG();
@@ -683,7 +673,7 @@ namespace GameMod
                         UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.red, 12);
                     }
                     position.x -= 150f;
-                    uie.SelectAndDrawItem((!MPAutoSelection.PrimaryNeverSelect[i] ? "+" : "-"), position, 2000 + i, false, 0.022f, 1f);
+                    uie.SelectAndDrawItem(!MPAutoSelection.PrimaryNeverSelect[i] ? "+" : "-", position, 2000 + i, false, 0.022f, 1f);
                     position.x += 150f;
                     uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);
                     position.y += 50;
@@ -759,7 +749,7 @@ namespace GameMod
             private static Color UIColorSecondaries;
         }
 
-
+        public static bool init = false;
 
     }
 }

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 
-namespace mod_WeaponSelection
+namespace GameMod
 {
     class MPAutoSelectionUI
     {

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -1,0 +1,842 @@
+﻿using Harmony;
+using Overload;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace mod_WeaponSelection
+{
+    class MPAutoSelectionUI
+    {
+        // Menu manager
+        [HarmonyPatch(typeof(MenuManager), "MpCustomizeUpdate")]
+        class MpCustomizeMenuLogic
+        {
+            public static int selected;
+            public static int selected2;
+            public static int loadout1LastTick;
+            public static int loadout2LastTick;
+
+            public static void Postfix()
+            {
+                selected = DrawMpAutoselectOrderingScreen.returnPrimarySelected();
+                selected2 = DrawMpAutoselectOrderingScreen.returnSecondarySelected();
+                switch (MenuManager.m_menu_sub_state)
+                {
+                    case MenuSubState.ACTIVE:
+                        if (MenuManager.m_menu_micro_state == 3)
+                        {
+                            switch (UIManager.m_menu_selection)
+                            {
+                                case 200:
+                                case 201:
+                                case 202:
+                                case 203:
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        MenuManager.m_menu_micro_state = UIManager.m_menu_selection - 200;
+                                        MenuManager.UIPulse(1f);
+                                        GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                                    }
+                                    break;
+                                case 1720:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(0);
+                                    break;
+                                case 1721:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(1);
+                                    break;
+                                case 1722:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(2);
+                                    break;
+                                case 1723:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(3);
+                                    break;
+                                case 1724:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(4);
+                                    break;
+                                case 1725:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(5);
+                                    break;
+                                case 1726:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(6);
+                                    break;
+                                case 1727:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(7);
+                                    break;
+                                case 1728:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(0);
+                                    break;
+                                case 1729:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(1);
+                                    break;
+                                case 1730:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(2);
+                                    break;
+                                case 1731:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(3);
+                                    break;
+                                case 1732:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(4);
+                                    break;
+                                case 1733:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(5);
+                                    break;
+                                case 1734:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(6);
+                                    break;
+                                case 1735:
+                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(7);
+                                    break;
+                                case 2000:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(0);
+                                    break;
+                                case 2001:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(1);
+                                    break;
+                                case 2002:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(2);
+                                    break;
+                                case 2003:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(3);
+                                    break;
+                                case 2004:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(4);
+                                    break;
+                                case 2005:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(5);
+                                    break;
+                                case 2006:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(6);
+                                    break;
+                                case 2007:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(7);
+                                    break;
+                                case 2010:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(0);
+                                    break;
+                                case 2011:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(1);
+                                    break;
+                                case 2012:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(2);
+                                    break;
+                                case 2013:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(3);
+                                    break;
+                                case 2014:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(4);
+                                    break;
+                                case 2015:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(5);
+                                    break;
+                                case 2016:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(6);
+                                    break;
+                                case 2017:
+                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(7);
+                                    break;
+                                case 2100:
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        if (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag)
+                                        {
+                                            MPAutoSelection.primarySwapFlag = false;
+                                            MPAutoSelection.secondarySwapFlag = false;
+                                            SFXCueManager.PlayCue2D(SFXCue.enemy_detonatorA_death_roll, 0.8f, 0f, 0f, false);
+                                            //SFXCueManager.PlayRawSoundEffect2D(SoundEffect.door_close2, 1f, -0.2f, 0.25f, false);
+                                        }
+                                        else
+                                        {
+                                            MPAutoSelection.primarySwapFlag = true;
+                                            MPAutoSelection.secondarySwapFlag = true;
+                                            SFXCueManager.PlayCue2D(SFXCue.enemy_detonatorB_alert, 0.8f, 0f, 0f, false);
+                                            // SFXCueManager.PlayRawSoundEffect2D(SoundEffect.door_open2, 1f, -0.2f, 0.25f, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.saveToFile();
+                                    }
+                                    break;
+                                case 2101: //REPLACE
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        if (MPAutoSelection.patchPrevNext)
+                                        {
+                                            MPAutoSelection.patchPrevNext = false;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_response_negative, 0.8f, 0f, 0f, false);
+                                        }
+                                        else
+                                        {
+                                            MPAutoSelection.patchPrevNext = true;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.saveToFile();
+                                    }
+                                    break;
+                                case 2102:
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        if (MPAutoSelection.secondarySwapFlag)
+                                        {
+                                            MPAutoSelection.secondarySwapFlag = false;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_response_negative, 0.8f, 0f, 0f, false);
+                                        }
+                                        else
+                                        {
+                                            MPAutoSelection.secondarySwapFlag = true;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.saveToFile();
+                                    }
+                                    break;
+                                case 2103:
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        if (MPAutoSelection.primarySwapFlag)
+                                        {
+                                            MPAutoSelection.primarySwapFlag = false;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_response_negative, 0.8f, 0f, 0f, false);
+                                        }
+                                        else
+                                        {
+                                            MPAutoSelection.primarySwapFlag = true;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.saveToFile();
+                                    }
+                                    break;
+                                case 2104: //
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        if (MPAutoSelection.zorc)
+                                        {
+                                            MPAutoSelection.zorc = false;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_response_negative, 0.8f, 0f, 0f, false);
+                                        }
+                                        else
+                                        {
+                                            MPAutoSelection.zorc = true;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.saveToFile();
+                                    }
+                                    break;
+                                case 2105: //
+                                    if (UIManager.PushedSelect(100))
+                                    {
+                                        if (MPAutoSelection.COswapToHighest)
+                                        {
+                                            MPAutoSelection.COswapToHighest = false;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_response_negative, 0.8f, 0f, 0f, false);
+                                        }
+                                        else
+                                        {
+                                            MPAutoSelection.COswapToHighest = true;
+                                            SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.saveToFile();
+                                    }
+                                    break;
+
+
+
+                                default:
+                                    if (UIManager.PushedSelect(100) && UIManager.m_menu_selection == 100)
+                                    {
+                                        uConsole.Log("Definitly 203 " + Player.Mp_loadout1 + " : " + Player.Mp_loadout2);
+                                        UIManager.DestroyAll(false);
+                                        MenuManager.PlaySelectSound(1f);
+                                        if (MPAutoSelection.isCurrentlyInLobby)
+                                        {
+                                            MenuManager.ChangeMenuState(MenuState.MP_PRE_MATCH_MENU, false);
+
+                                        }
+                                        else
+                                        {
+                                            MenuManager.ChangeMenuState(MenuState.MP_MENU, false);
+                                        }
+                                        DrawMpAutoselectOrderingScreen.isInitialised = false;
+
+                                    }
+                                    break;
+
+                            }
+                        }
+                        else
+                        {
+                            //uConsole.Log("NOT 203 "+Player.Mp_loadout1 + " : " + Player.Mp_loadout2);
+                            if (Player.Mp_loadout1 == 203 || Player.Mp_loadout2 == 203)
+                            {
+                                Player.Mp_loadout1 = loadout1LastTick;
+                                Player.Mp_loadout2 = loadout2LastTick;
+                            }
+                            else
+                            {
+                                loadout1LastTick = Player.Mp_loadout1;
+                                loadout2LastTick = Player.Mp_loadout2;
+                            }
+                            if (UIManager.PushedSelect(100) && UIManager.m_menu_selection == 203)
+                            {
+                                //MenuManager.SetDefaultSelection(-1);
+                                MenuManager.m_menu_micro_state = 3;
+                                MenuManager.UIPulse(1f);
+                                GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                            }
+
+                        }
+
+
+
+                        break;
+                }
+            }
+
+
+            private static void doNeverSelectStuffForPrimary(int i)
+            {
+                MPAutoSelection.PrimaryNeverSelect[i] = !MPAutoSelection.PrimaryNeverSelect[i];
+                if (!MPAutoSelection.PrimaryNeverSelect[i])
+                {
+                    SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                }
+                else
+                {
+                    SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                }
+                DrawMpAutoselectOrderingScreen.saveToFile();
+            }
+
+            private static void doNeverSelectStuffForSecondary(int i)
+            {
+                MPAutoSelection.SecondaryNeverSelect[i] = !MPAutoSelection.SecondaryNeverSelect[i];
+                if (!MPAutoSelection.SecondaryNeverSelect[i])
+                {
+                    SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                }
+                else
+                {
+                    SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                }
+                DrawMpAutoselectOrderingScreen.saveToFile();
+            }
+
+            private static void doSelectedStuffForPrimary(int i)
+            {
+                if (selected < 1)
+                {
+                    DrawMpAutoselectOrderingScreen.isPrimarySelected[i] = true;
+                    GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                }
+                else
+                {
+                    DrawMpAutoselectOrderingScreen.isPrimarySelected[i] = true;
+                    DrawMpAutoselectOrderingScreen.SwapSelectedPrimary();
+                    SFXCueManager.PlayCue2D(SFXCue.ui_upgrade, 0.8f, 0f, 0f, false);
+
+                }
+            }
+
+
+            private static void doSelectedStuffForSecondary(int i)
+            {
+                if (selected2 < 1)
+                {
+                    DrawMpAutoselectOrderingScreen.isSecondarySelected[i] = true;
+                    GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
+                }
+                else
+                {
+                    DrawMpAutoselectOrderingScreen.isSecondarySelected[i] = true;
+                    DrawMpAutoselectOrderingScreen.SwapSelectedSecondary();
+                    SFXCueManager.PlayCue2D(SFXCue.ui_upgrade, 0.8f, 0f, 0f, false);
+                }
+            }
+        }
+
+
+
+
+        // Adds the Auto order entry in the customize menu
+        // Todo: fix the iteration to account for the new element
+        [HarmonyPatch(typeof(UIElement), "DrawMpTabs")]
+        internal class AddFourthTab
+        {
+            public static bool Prefix(Vector2 pos, int tab_selected, UIElement __instance)
+            {
+                float w = 378f; // 511
+                __instance.DrawWideBox(pos, w, 22f, UIManager.m_col_ub2, __instance.m_alpha, 7);
+                string[] array = new string[]
+                {
+                __instance.GetMpTabName(0),
+                __instance.GetMpTabName(1),
+                __instance.GetMpTabName(2),
+                "AUTOSELECT"
+                };
+
+                for (int i = 0; i < array.Length; i++)
+                {
+                    pos.x = (((float)i - 1f) * 198f) - 99f;//265 -132
+                    __instance.TestMouseInRect(pos, 84f, 16f, 200 + i, false); // original value = 112
+                    if (UIManager.m_menu_selection == 200 + i)
+                    {
+                        __instance.DrawWideBox(pos, 84f, 19f, UIManager.m_col_ui4, __instance.m_alpha, 7);
+                    }
+                    if (i == tab_selected)
+                    {
+                        __instance.DrawWideBox(pos, 84f, 16f, UIManager.m_col_ui4, __instance.m_alpha, 12);
+                        __instance.DrawStringSmall(array[i], pos, 0.6f, StringOffset.CENTER, UIManager.m_col_ub3, 1f, -1f);
+                    }
+                    else
+                    {
+                        __instance.DrawWideBox(pos, 84f, 16f, UIManager.m_col_ui0, __instance.m_alpha, 8);
+                        __instance.DrawStringSmall(array[i], pos, 0.6f, StringOffset.CENTER, UIManager.m_col_ui1, 1f, -1f);
+                    }
+                }
+                return false;
+            }
+        }
+
+
+
+
+
+
+        [HarmonyPatch(typeof(UIElement), "DrawMpCustomize")]
+        internal class DrawMpAutoselectOrderingScreen
+        {
+            static string[] PrimaryPriorityArray = new string[8];
+            static string[] SecondaryPriorityArray = new string[8];
+
+            static void Postfix(UIElement __instance)
+            {
+                //Initialise();
+                if (isInitialised == false)
+                {
+                    Initialise();
+                    isInitialised = true; //should be set to false when leaving the MpCustomize Menu
+                }
+
+                int menu_micro_state = MenuManager.m_menu_micro_state;
+                if (menu_micro_state == 3)
+                {
+                    // Draw the Autoselect Ordering menu
+                    DrawPriorityList(__instance);
+                }
+            }
+
+            public static void Initialise()
+            {
+                Primary[0] = PrimaryPriorityArray[0];
+                Primary[1] = PrimaryPriorityArray[1];
+                Primary[2] = PrimaryPriorityArray[2];
+                Primary[3] = PrimaryPriorityArray[3];
+                Primary[4] = PrimaryPriorityArray[4];
+                Primary[5] = PrimaryPriorityArray[5];
+                Primary[6] = PrimaryPriorityArray[6];
+                Primary[7] = PrimaryPriorityArray[7];
+
+                Secondary[0] = SecondaryPriorityArray[0];
+                Secondary[1] = SecondaryPriorityArray[1];
+                Secondary[2] = SecondaryPriorityArray[2];
+                Secondary[3] = SecondaryPriorityArray[3];
+                Secondary[4] = SecondaryPriorityArray[4];
+                Secondary[5] = SecondaryPriorityArray[5];
+                Secondary[6] = SecondaryPriorityArray[6];
+                Secondary[7] = SecondaryPriorityArray[7];
+            }
+
+            public static bool isInitialised = false;
+
+            public static string[] Primary = {
+                PrimaryPriorityArray[0],
+                PrimaryPriorityArray[1],
+                PrimaryPriorityArray[2],
+                PrimaryPriorityArray[3],
+                PrimaryPriorityArray[4],
+                PrimaryPriorityArray[5],
+                PrimaryPriorityArray[6],
+                PrimaryPriorityArray[7],
+            };
+            public static string[] Secondary = {
+                SecondaryPriorityArray[0],
+                SecondaryPriorityArray[1],
+                SecondaryPriorityArray[2],
+                SecondaryPriorityArray[3],
+                SecondaryPriorityArray[4],
+                SecondaryPriorityArray[5],
+                SecondaryPriorityArray[6],
+                SecondaryPriorityArray[7]
+            };
+            public static bool[] isPrimarySelected = new bool[8];
+            public static bool[] isSecondarySelected = new bool[8];
+
+            public static int returnPrimarySelected()
+            {
+                int counter = 0;
+                for (int i = 0; i < 8; i++)
+                {
+                    if (isPrimarySelected[i])
+                    {
+                        counter++;
+                    }
+                }
+                return counter;
+            }
+
+            public static int returnSecondarySelected()
+            {
+                int counter = 0;
+                for (int i = 0; i < 8; i++)
+                {
+                    if (isSecondarySelected[i])
+                    {
+                        counter++;
+                    }
+                }
+                return counter;
+            }
+
+            public static void SwapSelectedPrimary()
+            {
+                int counter = 0;
+                int[] selection = { 0, 0 };
+                for (int i = 0; i < 8; i++)
+                {
+                    if (isPrimarySelected[i])
+                    {
+                        selection[counter] = i;
+                        counter++;
+                    }
+                    if (counter == 2)
+                    {
+                        break;
+                    }
+                }
+                string temp = Primary[selection[0]];
+                Primary[selection[0]] = Primary[selection[1]];
+                Primary[selection[1]] = temp;
+
+                isPrimarySelected[selection[0]] = false;
+                isPrimarySelected[selection[1]] = false;
+                MPAutoSelection.PrimaryNeverSelect[selection[0]] = false;
+                MPAutoSelection.PrimaryNeverSelect[selection[1]] = false;
+
+                saveToFile();
+                Initialise();
+            }
+
+            public static void SwapSelectedSecondary()
+            {
+                int counter = 0;
+                int[] selection = { 0, 0 };
+                for (int i = 0; i < 8; i++)
+                {
+                    if (isSecondarySelected[i])
+                    {
+                        selection[counter] = i;
+                        counter++;
+                    }
+                    if (counter == 2)
+                    {
+                        break;
+                    }
+                }
+                string temp = Secondary[selection[0]];
+                Secondary[selection[0]] = Secondary[selection[1]];
+                Secondary[selection[1]] = temp;
+
+                isSecondarySelected[selection[0]] = false;
+                isSecondarySelected[selection[1]] = false;
+                MPAutoSelection.SecondaryNeverSelect[selection[0]] = false;
+                MPAutoSelection.SecondaryNeverSelect[selection[1]] = false;
+
+                saveToFile();
+                Initialise();
+            }
+
+            public static void saveToFile()
+            {
+                using (StreamWriter sw = File.CreateText(MPAutoSelection.textFile))
+                {
+                    sw.WriteLine(Primary[0]);
+                    sw.WriteLine(Primary[1]);
+                    sw.WriteLine(Primary[2]);
+                    sw.WriteLine(Primary[3]);
+                    sw.WriteLine(Primary[4]);
+                    sw.WriteLine(Primary[5]);
+                    sw.WriteLine(Primary[6]);
+                    sw.WriteLine(Primary[7]);
+                    sw.WriteLine(Secondary[0]);
+                    sw.WriteLine(Secondary[1]);
+                    sw.WriteLine(Secondary[2]);
+                    sw.WriteLine(Secondary[3]);
+                    sw.WriteLine(Secondary[4]);
+                    sw.WriteLine(Secondary[5]);
+                    sw.WriteLine(Secondary[6]);
+                    sw.WriteLine(Secondary[7]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[0]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[1]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[2]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[3]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[4]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[5]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[6]);
+                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[7]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[0]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[1]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[2]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[3]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[4]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[5]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[6]);
+                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[7]);
+                    sw.WriteLine(MPAutoSelection.primarySwapFlag);
+                    sw.WriteLine(MPAutoSelection.secondarySwapFlag);
+                    sw.WriteLine(MPAutoSelection.COswapToHighest);
+                    sw.WriteLine(MPAutoSelection.patchPrevNext);
+                    sw.WriteLine(MPAutoSelection.zorc);
+                    sw.WriteLine(MPAutoSelection.miasmic);
+                }
+            }
+
+            public static string selectionToDescription(int n)
+            {
+                if (n == 2100)
+                {
+                    MPAutoSelection.last_valid_description = "TOGGLES WETHER THE WHOLE MOD SHOULD BE ACTIVE";
+                    return "TOGGLES WETHER THE WHOLE MOD SHOULD BE ACTIVE";
+                }
+                if (n == 2101)
+                {
+                    MPAutoSelection.last_valid_description = "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
+                    return "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
+                }
+                if (n <= 2017 && n >= 2000)
+                {
+                    MPAutoSelection.last_valid_description = "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
+                    return "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
+                }
+                if (n <= 1735 && n >= 1720)
+                {
+                    MPAutoSelection.last_valid_description = "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
+                    return "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
+                }
+                if (n == 2103)
+                {
+                    MPAutoSelection.last_valid_description = "TOGGLES EVERYTHING RELATED TO PRIMARY WEAPONS IN THIS MOD";
+                    return "TOGGLES EVERYTHING RELATED TO PRIMARY WEAPONS IN THIS MOD";
+                }
+                if (n == 2102)
+                {
+                    MPAutoSelection.last_valid_description = "TOGGLES EVERYTHING RELATED TO SECONDARY WEAPONS IN THIS MOD";
+                    return "TOGGLES EVERYTHING RELATED TO SECONDARY WEAPONS IN THIS MOD";
+                }
+                if (n == 2104)
+                {
+                    // Alert
+                    MPAutoSelection.last_valid_description = "DISPLAY A WARNING IF A DEVASTATOR GETS AUTOSELECTED";
+                    return "DISPLAY A WARNING IF A DEVASTATOR GETS AUTOSELECTED";
+                }
+                if (n == 2105)
+                {
+                    // On Swap
+                    MPAutoSelection.last_valid_description = "SETS WETHER ON PICKUP SHOULD SWAP TO THE PICKED UP (IF VALID) OR THE HIGHEST";
+                    return "SETS WETHER ON PICKUP SHOULD SWAP TO THE PICKED UP (IF VALID) OR THE HIGHEST";
+                }
+
+                else
+                {
+                    return MPAutoSelection.last_valid_description;
+                }
+            }
+
+            public static int getWeaponIconIndex(string weapon)
+            {
+                if (weapon.Equals("IMPULSE") || weapon.Equals("FALCON")) return 0;
+                if (weapon.Equals("CYCLONE") || weapon.Equals("MISSILE_POD")) return 1;
+                if (weapon.Equals("REFLEX") || weapon.Equals("HUNTER")) return 2;
+                if (weapon.Equals("CRUSHER") || weapon.Equals("CREEPER")) return 3;
+                if (weapon.Equals("DRILLER") || weapon.Equals("NOVA")) return 4;
+                if (weapon.Equals("FLAK") || weapon.Equals("DEVASTATOR")) return 5;
+                if (weapon.Equals("THUNDERBOLT") || weapon.Equals("TIMEBOMB")) return 6;
+                if (weapon.Equals("LANCER") || weapon.Equals("VORTEX")) return 7;
+                else
+                {
+                    uConsole.Log("-AUTOORDERSELECT- [ERROR] getWeaponIconIndex didnt recognise the given weapon string");
+                    return 0;
+                }
+            }
+
+
+            public static void DrawPriorityList(UIElement uie)
+            {
+                //uConsole.Log("x:" +UIManager.m_mouse_pos.x + "| y:"+ UIManager.m_mouse_pos.y);
+
+
+                UIManager.X_SCALE = 0.2f;
+                UIManager.ui_bg_dark = true;
+                uie.DrawMenuBG();
+                Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
+
+                position.y += 164f;
+                Vector2 position2 = position;
+
+
+                position.x -= 160f;
+                position2.x += 160f;
+                Vector2 temp_pos = position;
+
+                //this would be a good candidate to put into another method
+                //(string s, Vector2 pos, int selection, bool fade
+
+
+                Color ceas = UIManager.m_col_ui4;
+
+                Vector2 left = position;
+                Vector2 right = position;
+                left.x += 75;
+                right.x += 240;
+
+                //Draws the weapon / neverselect buttons
+                for (int i = 0; i < 8; i++)
+                {
+                    //uie.DrawWideBox(position, 100f, 28f, Color.red, 0.2f, 7); //TEST
+                    //UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30, Color.red, 12); //TEST
+                    //UIManager.DrawQuadUIInner(position, num, 10f, c, this.m_alpha, 11, 0.75f);
+
+                    int primaryindex = getWeaponIconIndex(PrimaryPriorityArray[i]); //temporary
+                    int secondaryindex = getWeaponIconIndex(SecondaryPriorityArray[i]);
+                    UIManager.DrawSpriteUI(left, 0.15f, 0.15f, ceas, uie.m_alpha, 26 + primaryindex);
+
+                    UIManager.DrawSpriteUI(right, 0.15f, 0.15f, ceas, uie.m_alpha, 104 + secondaryindex);
+
+                    left.y += 50;
+                    right.y += 50;
+
+                    if (MPAutoSelection.PrimaryNeverSelect[i]) // irgendwas mit i
+                    {
+                        uie.DrawWideBox(position, 100f, 28f, Color.red, 0.2f, 7);
+                        UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.red, 12);
+                    }
+                    position.x -= 150f;
+                    string s = "";
+                    if (!MPAutoSelection.PrimaryNeverSelect[i])
+                    {
+                        s += "+";
+                    }
+                    else
+                    {
+                        s += "-";
+                    }
+                    uie.SelectAndDrawItem(s, position, 2000 + i, false, 0.022f, 1f);
+                    position.x += 150f;
+                    uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);
+                    position.y += 50;
+                    if (MPAutoSelection.SecondaryNeverSelect[i])
+                    {
+                        uie.DrawWideBox(position2, 100f, 28f, Color.red, 0.2f, 7);
+                        UIManager.DrawQuadBarHorizontal(position2, 100f, 18f, 30, Color.red, 12);
+                    }
+                    position2.x += 150f;
+                    string a = "";
+                    if (!MPAutoSelection.SecondaryNeverSelect[i])
+                    {
+                        a += "+";
+                    }
+                    else
+                    {
+                        a += "-";
+                    }
+                    uie.SelectAndDrawItem(a, position2, 2010 + i, false, 0.022f, 1f);
+                    position2.x -= 150f;
+                    uie.SelectAndDrawHalfItem(Secondary[i], position2, 1728 + i, false);
+                    position2.y += 50;
+                }
+
+                position = Vector2.up * (UIManager.UI_TOP + 70f);
+                position.y += 164f;
+                position.x += 540f;
+                string mod = "";
+                string mod1 = "";
+                string mod2 = "";
+                if (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag)
+                {
+                    mod += "ACTIVE";
+                }
+                else
+                {
+                    mod += "INACTIVE";
+                }
+                if (MPAutoSelection.primarySwapFlag)
+                {
+                    mod1 += "ON";
+                }
+                else if (!MPAutoSelection.primarySwapFlag)
+                {
+                    mod1 += "OFF";
+                }
+                if (MPAutoSelection.secondarySwapFlag)
+                {
+                    mod2 += "ON";
+                }
+                else if (!MPAutoSelection.secondarySwapFlag)
+                {
+                    mod2 += "OFF";
+                }
+
+
+                uie.SelectAndDrawItem("Mod: " + mod, position, 2100, false, 0.3f, 0.45f);
+                position.y += 2f;
+                Vector2 cust;
+                cust.x = 542;
+                cust.y = 123;
+
+                /*
+                MPWeaponAutoSelection.drag.x = position.x;//UIManager.m_mouse_pos.x;
+                MPWeaponAutoSelection.drag.y = UIManager.m_mouse_pos.y;
+                uConsole.Log("x:" + UIManager.m_mouse_pos.x + "| y:" + UIManager.m_mouse_pos.y);*/
+
+
+                cust.x = 540;
+                cust.y = -123;
+                //UIManager.DrawQuadUIInner(cust, 97f, 1f, UIManager.m_col_ui2, 0.6f, 11, 0.75f);
+
+                position.y += 50f;
+                position.x += 5f;
+                uie.SelectAndDrawItem("Weapon Logic: " + mod1, position, 2103, false, 0.27f, 0.4f);
+                position.y += 50f;
+                uie.SelectAndDrawItem("Missile Logic: " + mod2, position, 2102, false, 0.27f, 0.4f);
+                cust.x = 540;
+                cust.y = -22;
+                //UIManager.DrawQuadUIInner(cust, 97f, 1f, UIManager.m_col_ui2, 0.6f, 11, 0.75f);
+                // 2101 is reserved for patch prev/next logic
+
+                string a1 = MPAutoSelection.patchPrevNext ? "ON" : "OFF";
+                string b = MPAutoSelection.zorc ? "ON" : "OFF";
+                string c = MPAutoSelection.COswapToHighest ? "HIGHEST" : "PICKUP";
+
+                position.x -= 5f;
+                position.y += 132; //original 147
+                //var MPWeaponAutoSelection.patchPrevNext
+                uie.SelectAndDrawItem("REPLACE: " + a1, position, 2101, false, 0.3f, 0.45f); // Possible Options: DEFAULT/PRIORITY
+                position.y += 50;
+                //var MPWeaponAutoSelection.zorc
+                uie.SelectAndDrawItem("ALERT: " + b, position, 2104, false, 0.3f, 0.45f); // Possible Options: OFF/ON
+                position.y += 50;
+                uie.SelectAndDrawItem("SWAP TO: " + c, position, 2105, false, 0.3f, 0.45f); // Possible Options: DEFAULT/PRIORITY
+
+                //this adds a short description of what the button that is currently selected does if its pressed
+                position2.x -= 160f;
+                position2.y -= 14f;
+                string k = selectionToDescription(UIManager.m_menu_selection);
+                MPAutoSelection.last_valid_description = k;
+                uie.DrawLabelSmall(position2, k, 500f);
+            }
+        }
+
+
+
+    }
+}

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -428,46 +428,46 @@ namespace mod_WeaponSelection
 
             public static void Initialise()
             {
-                Primary[0] = PrimaryPriorityArray[0];
-                Primary[1] = PrimaryPriorityArray[1];
-                Primary[2] = PrimaryPriorityArray[2];
-                Primary[3] = PrimaryPriorityArray[3];
-                Primary[4] = PrimaryPriorityArray[4];
-                Primary[5] = PrimaryPriorityArray[5];
-                Primary[6] = PrimaryPriorityArray[6];
-                Primary[7] = PrimaryPriorityArray[7];
+                Primary[0] = MPAutoSelection.PrimaryPriorityArray[0];
+                Primary[1] = MPAutoSelection.PrimaryPriorityArray[1];
+                Primary[2] = MPAutoSelection.PrimaryPriorityArray[2];
+                Primary[3] = MPAutoSelection.PrimaryPriorityArray[3];
+                Primary[4] = MPAutoSelection.PrimaryPriorityArray[4];
+                Primary[5] = MPAutoSelection.PrimaryPriorityArray[5];
+                Primary[6] = MPAutoSelection.PrimaryPriorityArray[6];
+                Primary[7] = MPAutoSelection.PrimaryPriorityArray[7];
 
-                Secondary[0] = SecondaryPriorityArray[0];
-                Secondary[1] = SecondaryPriorityArray[1];
-                Secondary[2] = SecondaryPriorityArray[2];
-                Secondary[3] = SecondaryPriorityArray[3];
-                Secondary[4] = SecondaryPriorityArray[4];
-                Secondary[5] = SecondaryPriorityArray[5];
-                Secondary[6] = SecondaryPriorityArray[6];
-                Secondary[7] = SecondaryPriorityArray[7];
+                Secondary[0] = MPAutoSelection.SecondaryPriorityArray[0];
+                Secondary[1] = MPAutoSelection.SecondaryPriorityArray[1];
+                Secondary[2] = MPAutoSelection.SecondaryPriorityArray[2];
+                Secondary[3] = MPAutoSelection.SecondaryPriorityArray[3];
+                Secondary[4] = MPAutoSelection.SecondaryPriorityArray[4];
+                Secondary[5] = MPAutoSelection.SecondaryPriorityArray[5];
+                Secondary[6] = MPAutoSelection.SecondaryPriorityArray[6];
+                Secondary[7] = MPAutoSelection.SecondaryPriorityArray[7];
             }
 
             public static bool isInitialised = false;
 
             public static string[] Primary = {
-                PrimaryPriorityArray[0],
-                PrimaryPriorityArray[1],
-                PrimaryPriorityArray[2],
-                PrimaryPriorityArray[3],
-                PrimaryPriorityArray[4],
-                PrimaryPriorityArray[5],
-                PrimaryPriorityArray[6],
-                PrimaryPriorityArray[7],
+                MPAutoSelection.PrimaryPriorityArray[0],
+                MPAutoSelection.PrimaryPriorityArray[1],
+                MPAutoSelection.PrimaryPriorityArray[2],
+                MPAutoSelection.PrimaryPriorityArray[3],
+                MPAutoSelection.PrimaryPriorityArray[4],
+                MPAutoSelection.PrimaryPriorityArray[5],
+                MPAutoSelection.PrimaryPriorityArray[6],
+                MPAutoSelection.PrimaryPriorityArray[7],
             };
             public static string[] Secondary = {
-                SecondaryPriorityArray[0],
-                SecondaryPriorityArray[1],
-                SecondaryPriorityArray[2],
-                SecondaryPriorityArray[3],
-                SecondaryPriorityArray[4],
-                SecondaryPriorityArray[5],
-                SecondaryPriorityArray[6],
-                SecondaryPriorityArray[7]
+                MPAutoSelection.SecondaryPriorityArray[0],
+                MPAutoSelection.SecondaryPriorityArray[1],
+                MPAutoSelection.SecondaryPriorityArray[2],
+                MPAutoSelection.SecondaryPriorityArray[3],
+                MPAutoSelection.SecondaryPriorityArray[4],
+                MPAutoSelection.SecondaryPriorityArray[5],
+                MPAutoSelection.SecondaryPriorityArray[6],
+                MPAutoSelection.SecondaryPriorityArray[7]
             };
             public static bool[] isPrimarySelected = new bool[8];
             public static bool[] isSecondarySelected = new bool[8];
@@ -524,7 +524,7 @@ namespace mod_WeaponSelection
                 MPAutoSelection.PrimaryNeverSelect[selection[1]] = false;
 
                 saveToFile();
-                Initialise();
+                MPAutoSelection.Initialise();
             }
 
             public static void SwapSelectedSecondary()
@@ -553,7 +553,7 @@ namespace mod_WeaponSelection
                 MPAutoSelection.SecondaryNeverSelect[selection[1]] = false;
 
                 saveToFile();
-                Initialise();
+                MPAutoSelection.Initialise();
             }
 
             public static void saveToFile()
@@ -605,47 +605,38 @@ namespace mod_WeaponSelection
             {
                 if (n == 2100)
                 {
-                    MPAutoSelection.last_valid_description = "TOGGLES WETHER THE WHOLE MOD SHOULD BE ACTIVE";
-                    return "TOGGLES WETHER THE WHOLE MOD SHOULD BE ACTIVE";
+                    return "TOGGLES WETHER THE WHOLE FMOD SHOULD BE ACTIVE";
                 }
                 if (n == 2101)
                 {
-                    MPAutoSelection.last_valid_description = "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
                     return "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
                 }
                 if (n <= 2017 && n >= 2000)
                 {
-                    MPAutoSelection.last_valid_description = "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
                     return "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
                 }
                 if (n <= 1735 && n >= 1720)
                 {
-                    MPAutoSelection.last_valid_description = "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
                     return "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
                 }
                 if (n == 2103)
                 {
-                    MPAutoSelection.last_valid_description = "TOGGLES EVERYTHING RELATED TO PRIMARY WEAPONS IN THIS MOD";
                     return "TOGGLES EVERYTHING RELATED TO PRIMARY WEAPONS IN THIS MOD";
                 }
                 if (n == 2102)
                 {
-                    MPAutoSelection.last_valid_description = "TOGGLES EVERYTHING RELATED TO SECONDARY WEAPONS IN THIS MOD";
                     return "TOGGLES EVERYTHING RELATED TO SECONDARY WEAPONS IN THIS MOD";
                 }
                 if (n == 2104)
                 {
                     // Alert
-                    MPAutoSelection.last_valid_description = "DISPLAY A WARNING IF A DEVASTATOR GETS AUTOSELECTED";
                     return "DISPLAY A WARNING IF A DEVASTATOR GETS AUTOSELECTED";
                 }
                 if (n == 2105)
                 {
                     // On Swap
-                    MPAutoSelection.last_valid_description = "SETS WETHER ON PICKUP SHOULD SWAP TO THE PICKED UP (IF VALID) OR THE HIGHEST";
                     return "SETS WETHER ON PICKUP SHOULD SWAP TO THE PICKED UP (IF VALID) OR THE HIGHEST";
                 }
-
                 else
                 {
                     return MPAutoSelection.last_valid_description;
@@ -672,9 +663,6 @@ namespace mod_WeaponSelection
 
             public static void DrawPriorityList(UIElement uie)
             {
-                //uConsole.Log("x:" +UIManager.m_mouse_pos.x + "| y:"+ UIManager.m_mouse_pos.y);
-
-
                 UIManager.X_SCALE = 0.2f;
                 UIManager.ui_bg_dark = true;
                 uie.DrawMenuBG();
@@ -683,14 +671,9 @@ namespace mod_WeaponSelection
                 position.y += 164f;
                 Vector2 position2 = position;
 
-
                 position.x -= 160f;
                 position2.x += 160f;
                 Vector2 temp_pos = position;
-
-                //this would be a good candidate to put into another method
-                //(string s, Vector2 pos, int selection, bool fade
-
 
                 Color ceas = UIManager.m_col_ui4;
 
@@ -702,12 +685,9 @@ namespace mod_WeaponSelection
                 //Draws the weapon / neverselect buttons
                 for (int i = 0; i < 8; i++)
                 {
-                    //uie.DrawWideBox(position, 100f, 28f, Color.red, 0.2f, 7); //TEST
-                    //UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30, Color.red, 12); //TEST
-                    //UIManager.DrawQuadUIInner(position, num, 10f, c, this.m_alpha, 11, 0.75f);
 
-                    int primaryindex = getWeaponIconIndex(PrimaryPriorityArray[i]); //temporary
-                    int secondaryindex = getWeaponIconIndex(SecondaryPriorityArray[i]);
+                    int primaryindex = getWeaponIconIndex(MPAutoSelection.PrimaryPriorityArray[i]); //temporary
+                    int secondaryindex = getWeaponIconIndex(MPAutoSelection.SecondaryPriorityArray[i]);
                     UIManager.DrawSpriteUI(left, 0.15f, 0.15f, ceas, uie.m_alpha, 26 + primaryindex);
 
                     UIManager.DrawSpriteUI(right, 0.15f, 0.15f, ceas, uie.m_alpha, 104 + secondaryindex);
@@ -730,6 +710,8 @@ namespace mod_WeaponSelection
                     {
                         s += "-";
                     }
+
+
                     uie.SelectAndDrawItem(s, position, 2000 + i, false, 0.022f, 1f);
                     position.x += 150f;
                     uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);


### PR DESCRIPTION
**Idea**:
- Add a D3 style weapon selection where the player can set priorities for the primary and secondary weapons
  that get used when the player picks up a weapon or runs out of ammo

**Implementation:**
- Adds a Menu under ` Multiplayer/Customise/AutoOrder` to
   swap priorities by clicking on the two weapons that should be swapped
   use the (+, -) buttons to mark/unmark weapons for neverselect
   use the (Status:) button to disable/enable the mod or just Primary/Secondary logic to just disable partly
   use the (Alert:) button to play a very conspicuous sound whenever the player picks up a Devastator to save my Dad
   use the (Swap to:) button to mark to what weapon it should swap when picking sth up
- Saves and Retrieves Data to/from  AutoSelect-Config.txt from the same directory as the output.log

**Documentation**
[MPAutoSelection.cs] // contains the switch logic, initialisation, harmony hooks related to the weapon swaps
  - GameManager.Start 
      * Populates the Priorities from the file AutoSelect-Config.txt or default values
      * Adds 3 Commands
         1. toggleprimaryorder  : toggles all logic related to primary weapons
         2. togglesecondary : toggles all logic related to secondary weapons
         3. toggle_hud : toggles some hud elements based on a patch Arne made for Miasmic a long time ago
   - Player.UnlockWeaponClient
       * Gets triggered when the player picks up a weapon, checks wether it should swap weapons and if so
          wether it should swap to the highest useable or to the picked up weapon (option: "swap to:" in menu)
   - Player.RpcSetMissileAmmo
       * Gets triggered when the missile count changes, checks wether it should swap missiles and if so
          wether it should swap to the highest useable or to the picked up missile (option: "swap to:" in menu)
   - Player.SwitchToEnergyWeapon
       * Selects the highest usable primary when the ammo is empty
   - Player.SwitchToAmmoWeapon
       * Selects the highest usable primary when the energy is empty
   - Player.MaybeSwitchToNextMissile
       * This swaps to the next highest prioritized missile after 250ms if the current missile ammo ran out
          (Note: This only works when Sniperpackets are turned off, otherwise it fails quietly)

[MPAutoSelectionUI.cs] // contains all code related to the Menu under ` Multiplayer/Customise/AutoOrder`
  - MenuManager.MpCustomizeUpdate
      * Adds the button logic for the AutoOrder menu and changes the menu iteration to account for the 4th
  - UIElement.DrawMpTabs
      * Draws the Option for the added 4th tab under "CUSTOMIZE"
  - MenuManager.ControlsOptionsUpdate
      * Makes sure that if the player selects sth other than "NEVER" under `Controls/Advanced Controls/Primary Autoselect`
         that the mod gets disabled
  - UIElement.DrawMpCustomize
      * Draws the added menu through `DrawPriorityList(__instance)`


 Note: i would love to rewrite it into a clean more compact object oriented version but this runs well and i wont have time to 
          do that before the end of the semester. 
(the reason i am bringing this mod up now is because this mod synergizes well with the classic mod that Tobias is currently building, it running stable and since i wanted to learn git anyway)