### PR TITLE
Add support for Box Lava Normal and Box Lava Alien entities

### DIFF
--- a/GameMod/CustomLevelResources.cs
+++ b/GameMod/CustomLevelResources.cs
@@ -42,7 +42,9 @@ namespace GameMod
             { "entity_prop_fan_tn3", "entity_prop_fan_tn3" },
             { "entity_prop_fan_tn4", "entity_prop_fan_tn4" },
             { "entity_prop_fan_tn_corner", "entity_prop_fan_tn_corner" },
-            { "entity_prop_reactor_om16", "entity_prop_reactor_om16" } };
+            { "entity_prop_reactor_om16", "entity_prop_reactor_om16" },
+            { "entity_trigger_box_lava_alien", "entity_trigger_box_lava_alien" },
+            { "entity_trigger_box_lava_normal", "entity_trigger_box_lava_normal" }	};
 
         static MethodInfo TargetMethod()
         {


### PR DESCRIPTION
These particle effects are placed from the Overload Level Editor, but they weren't getting loaded by the game.

A separate change to the editor is required for these effects to show with the proper size: [https://github.com/overload-development-community/OverloadLevelEditor/pull/6](url)