### PR TITLE
fix joystick mod initialization

### DIFF
--- a/GameMod/Controllers.cs
+++ b/GameMod/Controllers.cs
@@ -221,9 +221,6 @@ namespace GameMod
             string fn = PilotManager.FileName(PilotFileType.CONFIG) + "mod";
             for (int i = 0; i < Controls.m_controllers.Count; i++)
             {
-                int[] m_sensitivity = (int[])AccessTools.Field(typeof(Overload.Controller), "m_sensitivity").GetValue(Controls.m_controllers[i]);
-                int[] m_deadzone = (int[])AccessTools.Field(typeof(Overload.Controller), "m_deadzone").GetValue(Controls.m_controllers[i]);
-
                 Controllers.controllers.Add(new Controllers.Controller
                 {
                     axes = new List<Controllers.Controller.Axis>()
@@ -232,8 +229,8 @@ namespace GameMod
                 {
                     int dz_index = Controls.m_controllers[i].GetAxisDeadzone(j);
                     int sens_index = Controls.m_controllers[i].GetAxisSensitivity(j);
-                    float sens = (RWInput.sens_multiplier[m_sensitivity[sens_index]] / 2.2f) * 100f;
-                    float deadzone = (Controls.DEADZONE_ADDITIONAL[m_deadzone[dz_index]] / 0.5f) * 100f;
+                    float sens = (RWInput.sens_multiplier[sens_index] / 2.2f) * 100f;
+                    float deadzone = (Controls.DEADZONE_ADDITIONAL[dz_index] / 0.5f) * 100f;
 
                     Controllers.controllers[i].axes.Add(new Controllers.Controller.Axis()
                     {

--- a/GameMod/Controllers.cs
+++ b/GameMod/Controllers.cs
@@ -229,7 +229,7 @@ namespace GameMod
                 {
                     int dz_index = Controls.m_controllers[i].GetAxisDeadzone(j);
                     int sens_index = Controls.m_controllers[i].GetAxisSensitivity(j);
-                    float sens = (RWInput.sens_multiplier[sens_index] / 2.2f) * 100f;
+                    float sens = ((RWInput.sens_multiplier[sens_index] - 0.75f) / 1.45f) * 100f;
                     float deadzone = (Controls.DEADZONE_ADDITIONAL[dz_index] / 0.5f) * 100f;
 
                     Controllers.controllers[i].axes.Add(new Controllers.Controller.Axis()


### PR DESCRIPTION
This fixes two issues with the joystick mod. Both issues are related to converting the original player config into the new mod settings.

- Issue 1 leads to reading the values for the wrong axis, potentially preventing the game from starting by an out-of-range array access.
- Issue 2 is a wrong conversion from the old sensitivity settings to the new scale. 

Both issues are explained in detail in the respective commits.
