### PR TITLE
actually use the new velocity fields from the 0.3.6. protocol

### DIFF
--- a/GameMod/MPClientExtrapolation.cs
+++ b/GameMod/MPClientExtrapolation.cs
@@ -240,7 +240,7 @@ namespace GameMod {
                     m_last_update_time = Time.time;
                 } else {
                     // next in sequence, as we expected
-                    EnqueueToRing(msg, true);
+                    EnqueueToRing(msg, wasOld);
                     // this assumes the server sends 60Hz
                     // during time dilation (timebombs!) this is not true,
                     // it will actually send data packets _worth_ of 16.67ms real time, spread out


### PR DESCRIPTION
This fixes a regression from 9159fca1c700043d7977dff8414eaefef136111e
which accidently estimated the velocities from the previos snapshots
even if the new protocol with explicit velocities was used.