### PR TITLE
Don't render the UI collision mesh

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -171,6 +171,7 @@
     <Compile Include="ServerTrackerPost.cs" />
     <Compile Include="Menus.cs" />
     <Compile Include="Shaders.cs" />
+    <Compile Include="UIMeshColliderNoRender.cs" />
     <Compile Include="VSync.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GameMod/UIMeshColliderNoRender.cs
+++ b/GameMod/UIMeshColliderNoRender.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+using Harmony;
+using Overload;
+using UnityEngine;
+
+namespace GameMod {
+
+    [HarmonyPatch(typeof(UIManager), "GenerateUICollisionMesh")]
+    class UIMeshColliderNoRender_GenerateUICollisionMesh {
+        private static void Postfix() {
+            // url[4] seems to be the ui collision layer, it is never _meant_
+            // to be rendered at all, but only (mis?-)used by the game as a
+            // a helper to dynamically generate a Mesh for a MeshCollider
+            // which is later used for (CPU side) raycasting in
+            // UIManager.FindMousePosition().
+            // However, since this mesh is created in a render layer, it is
+            // actually rendered _every frame_ for no reason at all.
+            //
+            // NOTE: "UnityRenderLayer" is not an Unity concept, but something
+            // Luke Schneider came up with for his earlier games, see
+            // https://www.gamasutra.com/blogs/LukeSchneider/20120911/177488/XNAtoUnity_Part_1__The_Setup.php
+            // https://www.gamasutra.com/blogs/LukeSchneider/20120919/177963/XNAtoUnity_Part_2_Rendering.php
+            // It seems this stuff got re-used in Overload...
+            UnityRenderLayer renderLayer = Overload.UIManager.url[4];
+
+            // access the protected field "c_renderer" of the UnityRenderLayer
+            Type renderLayerType = renderLayer.GetType();
+            BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+            FieldInfo fieldInfo = renderLayerType.GetField("c_renderer", bindingFlags);
+            Renderer r = (Renderer)fieldInfo.GetValue(renderLayer);
+            r.enabled = false; // turn it off
+        }
+    }
+}


### PR DESCRIPTION
This improves the rendering performace. You can expect to observe
a boost in the range of 2% to 8% of your frame rate, depending on
your hardware and your settings.

In my test scenario on my machine, framerate on a particular spot
in vault went from ~160 to ~170 (+6%).

Overload uses a mesh to render the distorted menu and UI elements (also
in game). For the menu to be usable with the mouse, the distortion
has to be inverted. This is done by _another_ mesh which is almost
identical to the render mesh and is used only for CPU side raycasting in
UIManager.FindMousePosition().

However, for dynamically creating this collision-only mesh, Luke
Schneider's concept of "UnityRenderLayer" is used, But this has the
effect that we now have an "collision ui layer" lying around which has
its own Renderer and which actually renders the collision mesh
_each frame_, for no benefit at all.

This patch simply disables the renderer for the UI collision layer.