### PR TITLE
Move match length setting to number of seconds integer passed via MPModPrivateData

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -127,6 +127,7 @@
     <Compile Include="MPHUDMessage.cs" />
     <Compile Include="MPLongPwd.cs" />
     <Compile Include="MPMatchPresets.cs" />
+    <Compile Include="MPMatchTimeLimits.cs" />
     <Compile Include="MPModifiers.cs" />
     <Compile Include="MPModPrivateData.cs" />
     <Compile Include="MPNoDupes.cs" />

--- a/GameMod/MPMatchPresets.cs
+++ b/GameMod/MPMatchPresets.cs
@@ -34,7 +34,7 @@ namespace GameMod
                 matchMode = MenuManager.mms_mode,
                 maxPlayers = MenuManager.mms_max_players,
                 friendlyFire = MenuManager.mms_friendly_fire,
-                timeLimit = MenuManager.mms_time_limit,
+                timeLimit = Menus.mms_match_time_limit,
                 scoreLimit = MenuManager.mms_score_limit,
                 respawnTime = MenuManager.mms_respawn_time,
                 respawnInvuln = MenuManager.mms_respawn_invuln,
@@ -70,7 +70,7 @@ namespace GameMod
                 matchMode = MatchMode.ANARCHY,
                 maxPlayers = 16,
                 friendlyFire = 0,
-                timeLimit = MatchTimeLimit.MIN_15,
+                timeLimit = 15 * 60,
                 scoreLimit = 0,
                 respawnTime = 2,
                 respawnInvuln = 2,
@@ -109,7 +109,7 @@ namespace GameMod
             public MatchMode matchMode;
             public int maxPlayers;
             public int friendlyFire;
-            public MatchTimeLimit timeLimit;
+            public int timeLimit;
             public int scoreLimit;
             public int respawnTime;
             public int respawnInvuln;
@@ -143,7 +143,7 @@ namespace GameMod
                 MenuManager.mms_mode = this.matchMode;
                 MenuManager.mms_max_players = this.maxPlayers;
                 MenuManager.mms_friendly_fire = this.friendlyFire;
-                MenuManager.mms_time_limit = this.timeLimit;
+                Menus.mms_match_time_limit = this.timeLimit;
                 MenuManager.mms_score_limit = this.scoreLimit;
                 MenuManager.mms_respawn_time = this.respawnTime;
                 MenuManager.mms_respawn_invuln = this.respawnInvuln;

--- a/GameMod/MPMatchTimeLimits.cs
+++ b/GameMod/MPMatchTimeLimits.cs
@@ -19,7 +19,7 @@ namespace GameMod
             }
             else
             {
-                __result = (Menus.mms_match_time_limit / 60).ToString() + " MINUTES";
+                __result = (Menus.mms_match_time_limit / 60).ToString() + " MINUTE" + ((Menus.mms_match_time_limit > 60) ? "S" : "");
             }
             return false;
         }

--- a/GameMod/MPMatchTimeLimits.cs
+++ b/GameMod/MPMatchTimeLimits.cs
@@ -1,0 +1,28 @@
+﻿using Harmony;
+using Overload;
+
+namespace GameMod
+{
+    class MPMatchTimeLimits
+    {
+        public static int MatchTimeLimit = 600;
+    }
+
+    [HarmonyPatch(typeof(MenuManager), "GetMMSTimeLimit")]
+    class MPMatchTimeLimits_MenuManager_GetMMSTimeLimit
+    {
+        static bool Prefix(ref string __result)
+        {
+            if (Menus.mms_match_time_limit == 0)
+            {
+                __result = "NONE";
+            }
+            else
+            {
+                __result = (Menus.mms_match_time_limit / 60).ToString() + " MINUTES";
+            }
+            return false;
+        }
+    }
+
+}

--- a/GameMod/MPModPrivateData.cs
+++ b/GameMod/MPModPrivateData.cs
@@ -91,6 +91,12 @@ namespace GameMod {
             set { MPSmash.Enabled = value; }
         }
 
+        public static int MatchTimeLimit
+        {
+            get { return MPMatchTimeLimits.MatchTimeLimit; }
+            set { MPMatchTimeLimits.MatchTimeLimit = value; }
+        }
+
         public static JObject Serialize()
         {
             JObject jobject = new JObject();
@@ -110,6 +116,7 @@ namespace GameMod {
             jobject["alwayscloaked"] = AlwaysCloaked;
             jobject["allowsmash"] = AllowSmash;
             jobject["customprojdata"] = CustomProjdata;
+            jobject["matchtimelimit"] = MatchTimeLimit;
             return jobject;
         }
 
@@ -131,6 +138,8 @@ namespace GameMod {
             AlwaysCloaked = root["alwayscloaked"].GetBool(false);
             AllowSmash = root["allowsmash"].GetBool(false);
             CustomProjdata = root["customprojdata"].GetString(string.Empty);
+            MatchTimeLimit = root["matchtimelimit"].GetInt(600);
+            NetworkMatch.m_match_time_limit_seconds = MatchTimeLimit;
         }
 
         public static string GetModeString(MatchMode mode)
@@ -419,6 +428,7 @@ namespace GameMod {
             MPModPrivateData.CtfCarrierBoostEnabled = Menus.mms_ctf_boost;
             MPModPrivateData.AlwaysCloaked = Menus.mms_always_cloaked;
             MPModPrivateData.AllowSmash = Menus.mms_allow_smash;
+            MPModPrivateData.MatchTimeLimit = Menus.mms_match_time_limit == 0 ? int.MaxValue : Menus.mms_match_time_limit;
             if (Menus.mms_mp_projdata_fn != "STOCK")
             {
                 try

--- a/GameMod/MPModPrivateData.cs
+++ b/GameMod/MPModPrivateData.cs
@@ -138,8 +138,11 @@ namespace GameMod {
             AlwaysCloaked = root["alwayscloaked"].GetBool(false);
             AllowSmash = root["allowsmash"].GetBool(false);
             CustomProjdata = root["customprojdata"].GetString(string.Empty);
-            MatchTimeLimit = root["matchtimelimit"].GetInt(600);
-            NetworkMatch.m_match_time_limit_seconds = MatchTimeLimit;
+            MatchTimeLimit = root["matchtimelimit"].GetInt(-1);
+
+            // If client sent new match time limit, apply otherwise ignore (e.g. old olmod client)
+            if (MatchTimeLimit >= 0)
+                NetworkMatch.m_match_time_limit_seconds = MatchTimeLimit;
         }
 
         public static string GetModeString(MatchMode mode)

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -236,6 +236,7 @@ namespace GameMod {
                 Menus.mms_weapon_lag_compensation_scale = ModPrefs.GetInt("MP_PM_WEAPON_LAG_COMPENSATION_SCALE", Menus.mms_weapon_lag_compensation_scale);
                 Menus.mms_damageeffect_alpha_mult = ModPrefs.GetInt("MP_PM_DAMAGEEFFECT_ALPHA_MULT", Menus.mms_damageeffect_alpha_mult);
                 Menus.mms_damageeffect_drunk_blur_mult = ModPrefs.GetInt("MP_PM_DAMAGEEFFECT_DRUNK_BLUR_MULT", Menus.mms_damageeffect_drunk_blur_mult);
+                Menus.mms_match_time_limit = ModPrefs.GetInt("MP_PM_MATCH_TIME_LIMIT", Menus.mms_match_time_limit);
             }
             else // for compatability with old olmod, no need to add new settings
             {
@@ -285,6 +286,7 @@ namespace GameMod {
             ModPrefs.SetInt("MP_PM_SHIP_LAG_COMPENSATION_SCALE", Menus.mms_ship_lag_compensation_scale);
             ModPrefs.SetInt("MP_PM_DAMAGEEFFECT_ALPHA_MULT", Menus.mms_damageeffect_alpha_mult);
             ModPrefs.SetInt("MP_PM_DAMAGEEFFECT_DRUNK_BLUR_MULT", Menus.mms_damageeffect_drunk_blur_mult);
+            ModPrefs.SetInt("MP_PM_MATCH_TIME_LIMIT", Menus.mms_match_time_limit);
             ModPrefs.Flush(filename + "mod");
         }
 


### PR DESCRIPTION
(Note this value in the .json files for the presets should now be represented in seconds as well instead of the old enum - will need coordination or transition period)