### PR TITLE
Fix LAN match with more than 2 DNS servers

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -130,6 +130,7 @@
     <Compile Include="MPMatchPresets.cs" />
     <Compile Include="MPModifiers.cs" />
     <Compile Include="MPModPrivateData.cs" />
+    <Compile Include="MPMonoDNSFix.cs" />
     <Compile Include="MPNoDupes.cs" />
     <Compile Include="MPNoPositionCompression.cs" />
     <Compile Include="MPPickupCheck.cs" />

--- a/GameMod/MPMonoDNSFix.cs
+++ b/GameMod/MPMonoDNSFix.cs
@@ -1,0 +1,39 @@
+﻿using Harmony;
+using Overload;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace GameMod
+{
+    // do not call GetIPv4Properties on Windows, it crashes with >2 DNS servers
+    // it's only used for LoopbackInterfaceIndex which is a stub on Windows
+    // https://github.com/Unity-Technologies/mono/blob/unity-2017.4/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs#L101
+    [HarmonyPatch(typeof(BroadcastState), "EnumerateNetworkInterfaces")]
+    class MPMonoDNSFix
+    {
+        // only patch on Windows
+        private static bool Prepare() {
+            // https://github.com/Unity-Technologies/mono/blob/unity-2017.4/mcs/class/corlib/System/Environment.cs#L742
+            var runningOnWindows = ((int) System.Environment.OSVersion.Platform < 4);
+            return runningOnWindows;
+        }
+
+        private static System.Net.NetworkInformation.IPv4InterfaceProperties GetIPv4Properties(object ipProperties) {
+            return null;
+        }
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            int n = 0;
+            foreach (var code in codes)
+            {
+                if (code.opcode == OpCodes.Callvirt && ((MethodInfo)code.operand).Name == "GetIPv4Properties") {
+                    code.operand = typeof(MPMonoDNSFix).GetMethod("GetIPv4Properties", BindingFlags.NonPublic | BindingFlags.Static);
+                    n++;
+                }
+                yield return code;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Due to a Mono bug, Overload crashes if more than 2 DNS servers are
configured on Windows when client/server LAN support is activated.
The crashing call is actually not needed on Windows, this patch
disables this call when running on Windows.