### PR TITLE
Issue #90 - Implement weapon/secondary autoselect in single player/challenge mode - move settings out of multiplayer menus 

### DIFF
--- a/GameMod/ExtendedConfig.cs
+++ b/GameMod/ExtendedConfig.cs
@@ -1,0 +1,352 @@
+﻿using Harmony;
+using Overload;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace GameMod
+{
+    /// <summary>
+    ///    adds a config file per pilot in a way that allows keeping up backward compatibility
+    ///    for settings that dont belong into .xprefsmod due to their size.
+    ///           
+    ///  Author:  luponix 
+    ///  Created: 2021-06-03
+    /// </summary>
+    class ExtendedConfig
+    {
+        private const string file_extension = ".extendedconfig";
+        private static List<string> unknown_sections;
+
+
+        // On Game Loading or when selecting a different PILOT read or generate PILOT.extendedconfig
+        [HarmonyPatch(typeof(PilotManager), "Select", new Type[] { typeof(string) })]
+        internal class ExtendedConfig_PilotManager_Select
+        {
+            public static void Postfix( string name )
+            {
+                SetDefaultConfig();
+                string filepath = Path.Combine(Application.persistentDataPath, name + file_extension);
+                if ( File.Exists(filepath) )
+                {
+                    ReadConfigData(filepath);
+                }
+                ApplyConfigData();
+            }
+        }
+
+        // reads all lines and passes them to their respective functions to process them 
+        // unknown sections get stored in ExtendedConfig.unknown_lines to reattach them to the end when saving
+        private static void ReadConfigData( string filepath )
+        {
+            using (StreamReader sr = new StreamReader(filepath))
+            {
+                unknown_sections = new List<string>();
+                List<string> current_section = new List<string>();
+                string line = String.Empty;
+                string current_section_id = "unknown";
+
+                while ((line = sr.ReadLine()) != null)
+                {
+
+                    if( line.StartsWith("[SECTION:"))
+                    {
+                        if( known_sections.Contains(line) )
+                        {
+                            current_section_id = line;
+                        }
+                        else
+                        {
+                            current_section_id = "unknown";
+                            unknown_sections.Add(line);
+                        }
+                    }
+                    else if( line.Equals("[/END]") )
+                    {
+                        if (!current_section_id.Equals("unknown"))
+                        {
+                            PassSectionToFunction(current_section, current_section_id);
+                            current_section_id = "unknown";
+                            current_section.Clear();
+                        }
+                        else
+                        {
+                            unknown_sections.Add(line);
+                        }
+                    }
+                    else
+                    {
+                        if (current_section_id.Equals("unknown"))
+                        {
+                            unknown_sections.Add(line);
+                        }
+                        else
+                        {
+                            current_section.Add(line);
+                        }
+                    }
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(PilotManager), "SavePreferences")]
+        internal class ExtendedConfig_PilotManager_SavePreferences
+        {
+            public static void Postfix()
+            {
+                SaveActivePilot();
+            }
+        }
+        
+        [HarmonyPatch(typeof(Controls), "SaveControlData")]
+        internal class ExtendedConfig_Controls_SaveControlData
+        {
+            public static void Postfix()
+            {
+                SaveActivePilot();
+            }
+        }
+
+        [HarmonyPatch(typeof(PilotManager), "Create")]
+        internal class ExtendedConfig_PilotManager_Create
+        {
+            public static void Prefix()
+            {
+                SaveActivePilot();
+            }
+
+            public static void Postfix(string name, bool copy_prefs = false, bool copy_config = false)
+            {
+                if (!copy_prefs && !copy_config)
+                {
+                    SetDefaultConfig();
+                    unknown_sections = new List<string>();
+                }
+                SaveActivePilot();
+            }
+        }
+
+        [HarmonyPatch(typeof(Platform), "DeleteUserData")]
+        internal class ExtendedConfig_Platform_DeleteUserData
+        {
+            static void Postfix(string filename)
+            {
+                if (filename.EndsWith(".xprefs"))
+                {
+                    Platform.DeleteUserData(filename.Replace(".xprefs", file_extension));
+                }
+            }
+        }
+
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////
+        ///                           Add new Sections here:                                  ///
+        /////////////////////////////////////////////////////////////////////////////////////////
+
+        private static List<string> known_sections = new List<string> {
+            "[SECTION: AUTOSELECT]",
+
+        };
+        
+
+        private static void PassSectionToFunction(List<string> section, string section_name)
+        {
+            if (section_name.Equals("[SECTION: AUTOSELECT]"))
+            {
+                Section_AutoSelect.Load(section);
+            }
+
+
+
+        }
+
+        public static void SaveActivePilot()
+        {
+            string filepath = Path.Combine(Application.persistentDataPath, PilotManager.ActivePilot + file_extension);
+            using (StreamWriter w = File.CreateText(filepath))
+            {
+                w.WriteLine("[SECTION: AUTOSELECT]");
+                Section_AutoSelect.Save(w);
+                w.WriteLine("[/END]");
+
+
+
+
+                foreach (string line in unknown_sections)
+                {
+                    w.WriteLine(line);
+                }
+            }
+        }
+
+        private static void SetDefaultConfig()
+        {
+            Section_AutoSelect.Set();
+
+        }
+
+        public static void ApplyConfigData()
+        {
+            Section_AutoSelect.ApplySettings();
+
+        }
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////
+        ///                           SECTION SPECIFIC FUNCTIONS:                             ///
+        /////////////////////////////////////////////////////////////////////////////////////////
+
+        internal class Section_AutoSelect
+        {
+            public static Dictionary<string, string> settings;
+
+            public static void Load(List<string> settings)
+            {
+                Section_AutoSelect.settings = new Dictionary<string, string>();
+                string l;
+                foreach (string line in settings)
+                {
+                    l = RemoveWhitespace(line);
+                    string[] res = l.Split(':');
+                    if (res.Length == 2)
+                    {
+                        Section_AutoSelect.settings.Add(res[0], res[1]);
+                    }
+                    else
+                    {
+                        Debug.Log("Error in ExtendedConfig.ProcessAutoSelectSection: unexpected line split: " + line + ", Setting Default Values.");
+                        Set();
+                        return;
+                    }
+                }
+                ApplySettings();
+            }
+
+            public static void Save(StreamWriter w)
+            {
+                if (settings != null)
+                {
+                    foreach (var setting in settings)
+                    {
+                        if (setting.Key != null && setting.Value != null)
+                        {
+                            w.WriteLine("   " + setting.Key + ": " + setting.Value);
+                        }
+                    }
+                }
+            }
+
+            // sets the values of the AutoSelect dictionary
+            //  mirror = false   sets the default values
+            //  mirror = true    sets the current MPAutoSelection values
+            public static void Set( bool mirror = false )
+            {
+                settings = new Dictionary<string, string>();
+                settings.Add("p_priority_0", mirror ? MPAutoSelection.PrimaryPriorityArray[0] : "THUNDERBOLT");
+                settings.Add("p_priority_1", mirror ? MPAutoSelection.PrimaryPriorityArray[1] : "CYCLONE");
+                settings.Add("p_priority_2", mirror ? MPAutoSelection.PrimaryPriorityArray[2] : "DRILLER");
+                settings.Add("p_priority_3", mirror ? MPAutoSelection.PrimaryPriorityArray[3] : "IMPULSE");
+                settings.Add("p_priority_4", mirror ? MPAutoSelection.PrimaryPriorityArray[4] : "FLAK");
+                settings.Add("p_priority_5", mirror ? MPAutoSelection.PrimaryPriorityArray[5] : "CRUSHER");
+                settings.Add("p_priority_6", mirror ? MPAutoSelection.PrimaryPriorityArray[6] : "LANCER");
+                settings.Add("p_priority_7", mirror ? MPAutoSelection.PrimaryPriorityArray[7] : "REFLEX");
+                settings.Add("s_priority_0", mirror ? MPAutoSelection.SecondaryPriorityArray[0] : "DEVASTATOR");
+                settings.Add("s_priority_1", mirror ? MPAutoSelection.SecondaryPriorityArray[1] : "NOVA");
+                settings.Add("s_priority_2", mirror ? MPAutoSelection.SecondaryPriorityArray[2] : "TIMEBOMB");
+                settings.Add("s_priority_3", mirror ? MPAutoSelection.SecondaryPriorityArray[3] : "VORTEX");
+                settings.Add("s_priority_4", mirror ? MPAutoSelection.SecondaryPriorityArray[4] : "HUNTER");
+                settings.Add("s_priority_5", mirror ? MPAutoSelection.SecondaryPriorityArray[5] : "FALCON");
+                settings.Add("s_priority_6", mirror ? MPAutoSelection.SecondaryPriorityArray[6] : "MISSILE_POD");
+                settings.Add("s_priority_7", mirror ? MPAutoSelection.SecondaryPriorityArray[7] : "CREEPER");
+                settings.Add("p_neverselect_0", mirror ? MPAutoSelection.PrimaryNeverSelect[0].ToString() : "false");
+                settings.Add("p_neverselect_1", mirror ? MPAutoSelection.PrimaryNeverSelect[1].ToString() : "false");
+                settings.Add("p_neverselect_2", mirror ? MPAutoSelection.PrimaryNeverSelect[2].ToString() : "false");
+                settings.Add("p_neverselect_3", mirror ? MPAutoSelection.PrimaryNeverSelect[3].ToString() : "false");
+                settings.Add("p_neverselect_4", mirror ? MPAutoSelection.PrimaryNeverSelect[4].ToString() : "false");
+                settings.Add("p_neverselect_5", mirror ? MPAutoSelection.PrimaryNeverSelect[5].ToString() : "false");
+                settings.Add("p_neverselect_6", mirror ? MPAutoSelection.PrimaryNeverSelect[6].ToString() : "false");
+                settings.Add("p_neverselect_7", mirror ? MPAutoSelection.PrimaryNeverSelect[7].ToString() : "false");
+                settings.Add("s_neverselect_0", mirror ? MPAutoSelection.SecondaryNeverSelect[0].ToString() : "false");
+                settings.Add("s_neverselect_1", mirror ? MPAutoSelection.SecondaryNeverSelect[1].ToString() : "false");
+                settings.Add("s_neverselect_2", mirror ? MPAutoSelection.SecondaryNeverSelect[2].ToString() : "false");
+                settings.Add("s_neverselect_3", mirror ? MPAutoSelection.SecondaryNeverSelect[3].ToString() : "false");
+                settings.Add("s_neverselect_4", mirror ? MPAutoSelection.SecondaryNeverSelect[4].ToString() : "false");
+                settings.Add("s_neverselect_5", mirror ? MPAutoSelection.SecondaryNeverSelect[5].ToString() : "false");
+                settings.Add("s_neverselect_6", mirror ? MPAutoSelection.SecondaryNeverSelect[6].ToString() : "false");
+                settings.Add("s_neverselect_7", mirror ? MPAutoSelection.SecondaryNeverSelect[7].ToString() : "false");
+                settings.Add("p_swap", mirror ? MPAutoSelection.primarySwapFlag.ToString() : "false");
+                settings.Add("s_swap", mirror ? MPAutoSelection.secondarySwapFlag.ToString() : "false");
+                settings.Add("dev_alert", mirror ? MPAutoSelection.zorc.ToString() : "true");
+                settings.Add("reduced_hud", mirror ? MPAutoSelection.miasmic.ToString() : "false");
+                settings.Add("swap_while_firing", mirror ? MPAutoSelection.swapWhileFiring.ToString() : "false");
+                settings.Add("dont_autoselect_after_firing", mirror ? MPAutoSelection.dontAutoselectAfterFiring.ToString() : "false");
+            }
+
+
+            public static void ApplySettings()
+            {
+                try
+                {
+                    MPAutoSelection.PrimaryPriorityArray[0] = settings["p_priority_0"];
+                    MPAutoSelection.PrimaryPriorityArray[1] = settings["p_priority_1"];
+                    MPAutoSelection.PrimaryPriorityArray[2] = settings["p_priority_2"];
+                    MPAutoSelection.PrimaryPriorityArray[3] = settings["p_priority_3"];
+                    MPAutoSelection.PrimaryPriorityArray[4] = settings["p_priority_4"];
+                    MPAutoSelection.PrimaryPriorityArray[5] = settings["p_priority_5"];
+                    MPAutoSelection.PrimaryPriorityArray[6] = settings["p_priority_6"];
+                    MPAutoSelection.PrimaryPriorityArray[7] = settings["p_priority_7"];
+                    MPAutoSelection.SecondaryPriorityArray[0] = settings["s_priority_0"];
+                    MPAutoSelection.SecondaryPriorityArray[1] = settings["s_priority_1"];
+                    MPAutoSelection.SecondaryPriorityArray[2] = settings["s_priority_2"];
+                    MPAutoSelection.SecondaryPriorityArray[3] = settings["s_priority_3"];
+                    MPAutoSelection.SecondaryPriorityArray[4] = settings["s_priority_4"];
+                    MPAutoSelection.SecondaryPriorityArray[5] = settings["s_priority_5"];
+                    MPAutoSelection.SecondaryPriorityArray[6] = settings["s_priority_6"];
+                    MPAutoSelection.SecondaryPriorityArray[7] = settings["s_priority_7"];
+                    MPAutoSelection.PrimaryNeverSelect[0] = Convert.ToBoolean(settings["p_neverselect_0"]);
+                    MPAutoSelection.PrimaryNeverSelect[1] = Convert.ToBoolean(settings["p_neverselect_1"]);
+                    MPAutoSelection.PrimaryNeverSelect[2] = Convert.ToBoolean(settings["p_neverselect_2"]);
+                    MPAutoSelection.PrimaryNeverSelect[3] = Convert.ToBoolean(settings["p_neverselect_3"]);
+                    MPAutoSelection.PrimaryNeverSelect[4] = Convert.ToBoolean(settings["p_neverselect_4"]);
+                    MPAutoSelection.PrimaryNeverSelect[5] = Convert.ToBoolean(settings["p_neverselect_5"]);
+                    MPAutoSelection.PrimaryNeverSelect[6] = Convert.ToBoolean(settings["p_neverselect_6"]);
+                    MPAutoSelection.PrimaryNeverSelect[7] = Convert.ToBoolean(settings["p_neverselect_7"]);
+                    MPAutoSelection.SecondaryNeverSelect[0] = Convert.ToBoolean(settings["s_neverselect_0"]);
+                    MPAutoSelection.SecondaryNeverSelect[1] = Convert.ToBoolean(settings["s_neverselect_1"]);
+                    MPAutoSelection.SecondaryNeverSelect[2] = Convert.ToBoolean(settings["s_neverselect_2"]);
+                    MPAutoSelection.SecondaryNeverSelect[3] = Convert.ToBoolean(settings["s_neverselect_3"]);
+                    MPAutoSelection.SecondaryNeverSelect[4] = Convert.ToBoolean(settings["s_neverselect_4"]);
+                    MPAutoSelection.SecondaryNeverSelect[5] = Convert.ToBoolean(settings["s_neverselect_5"]);
+                    MPAutoSelection.SecondaryNeverSelect[6] = Convert.ToBoolean(settings["s_neverselect_6"]);
+                    MPAutoSelection.SecondaryNeverSelect[7] = Convert.ToBoolean(settings["s_neverselect_7"]);
+                    MPAutoSelection.primarySwapFlag = Convert.ToBoolean(settings["p_swap"]);
+                    MPAutoSelection.secondarySwapFlag = Convert.ToBoolean(settings["s_swap"]);
+                    MPAutoSelection.zorc = Convert.ToBoolean(settings["dev_alert"]);
+                    MPAutoSelection.miasmic = Convert.ToBoolean(settings["reduced_hud"]);
+                    MPAutoSelection.swapWhileFiring = Convert.ToBoolean(settings["swap_while_firing"]);
+                    MPAutoSelection.dontAutoselectAfterFiring = Convert.ToBoolean(settings["dont_autoselect_after_firing"]);
+                }
+                catch( Exception ex )
+                {
+                    Debug.Log("Error while parsing AutoSelect settings. missing entry "+ex+"\nSetting Default values");
+                    Set();
+                    ApplySettings();
+                }
+            }
+
+            public static string RemoveWhitespace(string str)
+            {
+                return string.Join("", str.Split(default(string[]), StringSplitOptions.RemoveEmptyEntries));
+            }
+        }
+
+
+
+    }
+}
+

--- a/GameMod/ExtendedConfig.cs
+++ b/GameMod/ExtendedConfig.cs
@@ -27,6 +27,12 @@ namespace GameMod
         {
             public static void Prefix(string name)
             {
+                if( Network.isServer )
+                {
+                    Debug.Log("ExtendedConfig_PilotManager_Select called on the server");
+                    return;
+                }
+
                 SetDefaultConfig();
                 if (!string.IsNullOrEmpty(name))
                 {
@@ -100,6 +106,11 @@ namespace GameMod
         {
             public static void Postfix()
             {
+                if (Network.isServer)
+                {
+                    Debug.Log("ExtendedConfig_Controls_SaveControlData called on the server");
+                    return;
+                }
                 SaveActivePilot();
             }
         }
@@ -109,7 +120,12 @@ namespace GameMod
         {
             public static void Prefix()
             {
-                if( string.IsNullOrEmpty(PilotManager.ActivePilot) )
+                if (Network.isServer)
+                {
+                    Debug.Log("ExtendedConfig_PilotManager_Create called on the server");
+                    return;
+                }
+                if ( string.IsNullOrEmpty(PilotManager.ActivePilot) )
                 {
                     SetDefaultConfig();
                 }
@@ -118,6 +134,11 @@ namespace GameMod
 
             public static void Postfix(string name, bool copy_prefs, bool copy_config)
             {
+                if (Network.isServer)
+                {
+                    Debug.Log(" called on the server");
+                    return;
+                }
                 if (!copy_prefs && !copy_config)
                 {
                     SetDefaultConfig();
@@ -132,6 +153,11 @@ namespace GameMod
         {
             static void Postfix(string filename)
             {
+                if (Network.isServer)
+                {
+                    Debug.Log("ExtendedConfig_Platform_DeleteUserData called on the server");
+                    return;
+                }
                 if (filename.EndsWith(".xprefs"))
                 {
                     Platform.DeleteUserData(filename.Replace(".xprefs", file_extension));
@@ -380,6 +406,17 @@ namespace GameMod
                 {
                     public Vector2[] curve_points = new Vector2[4];
                     public float[] curve_lookup = new float[200];
+
+                    public Vector2[] CloneCurvePoints()
+                    {
+                        return new Vector2[] { 
+                            new Vector2(curve_points[0].x,curve_points[0].y), 
+                            new Vector2(curve_points[1].x,curve_points[1].y), 
+                            new Vector2(curve_points[2].x,curve_points[2].y), 
+                            new Vector2(curve_points[3].x,curve_points[3].y)
+                        };
+
+                    }
                 }
             }
 
@@ -423,6 +460,7 @@ namespace GameMod
                 {
                     Debug.Log("Error in ExtendedConfig.Section_JoystickCurve.Load:  " + ex + ", Setting Default Values.");
                     SetDefault();
+
                 }
             }
 

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -37,22 +37,22 @@
       <HintPath>.\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\DotNetZip.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Rewired_Core">
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Rewired_Core.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\Rewired_Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -62,38 +62,38 @@
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.Networking.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.Networking.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -108,6 +108,7 @@
     <Compile Include="FastLoad.cs" />
     <Compile Include="FrameTime.cs" />
     <Compile Include="GameMod.cs" />
+    <Compile Include="JoystickCurveEditor.cs" />
     <Compile Include="LevelError.cs" />
     <Compile Include="MatchModeRace.cs" />
     <Compile Include="MessageTypes.cs" />

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -37,22 +37,22 @@
       <HintPath>.\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\DotNetZip.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Rewired_Core">
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\Rewired_Core.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\Rewired_Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -62,38 +62,38 @@
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.Networking.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.Networking.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Overload\Overload_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -104,6 +104,7 @@
     <Compile Include="CTF.cs" />
     <Compile Include="CustomLevelResources.cs" />
     <Compile Include="DisableTimeCheat.cs" />
+    <Compile Include="ExtendedConfig.cs" />
     <Compile Include="FastLoad.cs" />
     <Compile Include="FrameTime.cs" />
     <Compile Include="GameMod.cs" />

--- a/GameMod/JoystickCurveEditor.cs
+++ b/GameMod/JoystickCurveEditor.cs
@@ -17,7 +17,7 @@ namespace GameMod
     /// </summary>
     class JoystickCurveEditor
     {
-        
+        /*
         internal class DebugOutput
         {
             public static InputAdjustment[] axes = new InputAdjustment[100];
@@ -60,7 +60,7 @@ namespace GameMod
                 }
             }
         }
-
+        */
 
 
 
@@ -547,8 +547,7 @@ namespace GameMod
                 }
                 __result = result * (neg ? -1f : 1f);
 
-                // todo: dont forget to remove this
-                
+                /*
                 if (control_num < 100 && control_num > -1)
                 {
                     DebugOutput.axes[control_num] = new DebugOutput.InputAdjustment
@@ -558,7 +557,7 @@ namespace GameMod
                         last_original_input = axis_value,
                         last_adjusted_input = result
                     };
-                }
+                }*/
 
                 return false;
 

--- a/GameMod/JoystickCurveEditor.cs
+++ b/GameMod/JoystickCurveEditor.cs
@@ -1,0 +1,570 @@
+﻿using Harmony;
+using Overload;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace GameMod
+{
+    /// <summary>
+    ///  Goal:    providing the option to set a curve for each controller axis.
+    ///           The curve gets created through 4 points. 2 of them are fixed along the x axis while the other two are 
+    ///           freely moveable (within (0,0)->(1,1)) and act as "weights" to form a 4 point Bezier curve.      
+    /// 
+    ///  Author:  luponix 
+    ///  Created: 2021-04-15
+    /// </summary>
+    class JoystickCurveEditor
+    {
+        
+        internal class DebugOutput
+        {
+            public static InputAdjustment[] axes = new InputAdjustment[100];
+
+            public class InputAdjustment
+            {
+                public int controller_num;
+                public int control_num;
+                public float last_original_input;
+                public float last_adjusted_input;
+            }
+
+            [HarmonyPatch(typeof(UIElement), "DrawHUD")]
+            class JoystickCurveEditor_DebugOutput_UIElement_DrawHUD
+            {
+                static void Postfix(UIElement __instance)
+                {
+
+                    Vector2 pos = new Vector2(-625f, -300f);
+                    for (int i = 0; i < axes.Length; i++)
+                    {
+                        if (axes[i] != null)
+                        {
+                            __instance.DrawStringSmall(Controls.m_controllers[axes[i].controller_num].name + ":" + axes[i].control_num, pos, 0.32f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                            pos.x += 260f;
+                            __instance.DrawStringSmall(axes[i].last_original_input.ToString("n3"), pos, 0.45f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                            pos.x += 65f;
+                            __instance.DrawStringSmall(axes[i].last_adjusted_input.ToString("n3"), pos, 0.45f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                            pos.y += 18f;
+                            pos.x -= 260f;
+                            pos.x -= 65f;
+                            axes[i].last_original_input = 0;
+                            axes[i].last_adjusted_input = 0;
+                        }
+                    }
+                    pos.y += 38f;
+                    __instance.DrawStringSmall("Turnrate        :", pos, 0.45f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                    pos.x += 260f;
+                    __instance.DrawStringSmall( GameManager.m_local_player.c_player_ship.c_rigidbody.angularVelocity.magnitude.ToString("n3"), pos, 0.45f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                }
+            }
+        }
+
+
+
+
+        // Adds an "EDIT CURVE" Button under "Options/Control Options/Joystick/Axis" 
+        [HarmonyPatch(typeof(UIElement), "DrawControlsMenu")]
+        internal class JoystickCurveEditor_DrawControlsMenu
+        {
+            private static void DrawEditCurveOption(UIElement uie, ref Vector2 position)
+            {
+                position.y += 62f;
+                uie.SelectAndDrawItem(Loc.LS("EDIT CURVE"), position, 12, false, 1f, 0.75f);
+                position.y -= 20f;
+            }
+
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                var codes = new List<CodeInstruction>(instructions);
+                int state = 0;
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    // adjusts the spacing to make some room
+                    if (state == 0 && codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "CONTROLLER DISCONNECTED" && codes[i + 11].opcode == OpCodes.Ldc_R4)
+                    {
+                        state++;
+                        codes[i + 11].operand = -230f;
+                    }
+                    if (state == 1 && codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "CURRENT SETTINGS:  MIN {0}  MAX {1}  ZERO {2}")
+                    {
+                        state++;
+                        if (codes[i - 13].opcode == OpCodes.Ldc_R4) codes[i - 13].operand = 71f;
+                    }
+
+                    // adds the Edit Curve Button
+                    if (state == 2 && codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "CALIBRATE")
+                    {
+                        var newCodes = new[] {
+                            new CodeInstruction(OpCodes.Ldarg_0),
+                            new CodeInstruction(OpCodes.Ldloca, 0),
+                            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(JoystickCurveEditor_DrawControlsMenu), "DrawEditCurveOption"))
+                        };
+                        codes.InsertRange(i + 7, newCodes);
+                        break;
+                    }
+                }
+                return codes;
+            }
+        }
+
+        // changes the menu state if the "EDIT CURVE" Button gets pressed
+        [HarmonyPatch(typeof(MenuManager), "ControlsOptionsUpdate")]
+        class JoystickCurveEditor_MenuManager_ControlsOptionsUpdate
+        {
+            static void Postfix()
+            {
+                if (UIManager.PushedSelect(100) || (MenuManager.option_dir && UIManager.PushedDir()) || UIManager.SliderMouseDown())
+                {
+                    switch (UIManager.m_menu_selection)
+                    {
+                        case 12:
+                            MenuManager.ChangeMenuState(Menus.msAxisCurveEditor, false);
+                            UIManager.DestroyAll(false);
+                            MenuManager.PlaySelectSound(1f);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+
+        // process the curve editor logic if we entered this menustate
+        private static int move_point = -1;
+        [HarmonyPatch(typeof(MenuManager), "Update")]
+        class JoystickCurveEditor_MenuManager_Update
+        {
+
+            private static void Postfix(ref float ___m_menu_state_timer)
+            {
+                if (MenuManager.m_menu_state == Menus.msAxisCurveEditor)
+                    JoystickCurveEditorUpdate(ref ___m_menu_state_timer);
+            }
+
+
+            private static void JoystickCurveEditorUpdate(ref float m_menu_state_timer)
+            {
+                UIManager.MouseSelectUpdate();
+                switch (MenuManager.m_menu_sub_state)
+                {
+                    case MenuSubState.INIT:
+                        if (m_menu_state_timer > 0.25f)
+                        {
+                            UIManager.CreateUIElement(UIManager.SCREEN_CENTER, 7000, Menus.uiAxisCurveEditor);
+                            MenuManager.m_menu_sub_state = MenuSubState.ACTIVE;
+                            m_menu_state_timer = 0f;
+                            MenuManager.SetDefaultSelection(0);
+                        }
+                        break;
+                    case MenuSubState.ACTIVE:
+                        UIManager.ControllerMenu();
+                        Controls.m_disable_menu_letter_keys = false;
+                        int menu_micro_state = MenuManager.m_menu_micro_state;
+
+                        if (m_menu_state_timer > 0.25f)
+                        {
+                            if (UIManager.PushedSelect(100) || (MenuManager.option_dir && UIManager.PushedDir() || UIManager.SliderMouseDown()))
+                            {
+                                MenuManager.MaybeReverseOption();
+                                MenuManager.m_calibration_step = -1;
+                                Controller controller2 = Controls.m_controllers[MenuManager.m_calibration_current_controller];
+                                switch (UIManager.m_menu_selection)
+                                {
+                                    case 233:     // set linear button
+                                        MenuManager.PlaySelectSound(1f);
+                                        if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                                        {
+                                            Vector2 start = ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[0];
+                                            Vector2 end = ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[3];
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[1] = new Vector2(0.25f, start.y + 0.25f * (end.y - start.y));
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[2] = new Vector2(0.75f, start.y + 0.75f * (end.y - start.y));
+                                        }
+                                        break;
+                                    case 234:     // reset curve button
+                                        MenuManager.PlaySelectSound(1f);
+                                        if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                                        {
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[0] = new Vector2(0, 0f);
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[1] = new Vector2(0.25f, 0.25f);
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[2] = new Vector2(0.75f, 0.75f);
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[3] = new Vector2(1f, 1f);
+                                        }
+                                        break;
+                                    case 100:
+                                        MenuManager.PlaySelectSound(1f);
+                                        if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                                        {
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_lookup = ExtendedConfig.Section_JoystickCurve.GenerateCurveLookupTable(ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points);
+                                        }
+                                        m_menu_state_timer = 0f;
+                                        UIManager.DestroyAll(false);
+                                        MenuManager.m_menu_state = 0;
+                                        MenuManager.m_menu_micro_state = 0;
+                                        MenuManager.m_menu_sub_state = MenuSubState.BACK;
+                                        break;
+                                }
+                            }
+
+                        }
+                        if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                        {
+                            ExtendedConfig.Section_JoystickCurve.Controller.Axis axis = ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis];
+                            Vector2 initial_pos = new Vector2(0, -22f);
+                            int xrange = 500;
+                            int yrange = 500;
+
+                            int limitx = xrange / 2;
+                            int limity = yrange / 2;
+                            initial_pos.x -= limitx;
+                            initial_pos.y += limity;
+                            if (move_point > -1 && move_point < 4) // if a valid point got selected and should be moved
+                            {
+                                if (Input.GetMouseButton(0)) // left mouse button still pressed ?
+                                {
+                                    Vector2 mouse_pos = UIManager.m_mouse_pos;
+                                    mouse_pos -= initial_pos;
+                                    if (!TestMouseInRect(new Vector2(0, -22f), 250f, 250f)) // make sure that the point boundaries are respected
+                                    {
+                                        mouse_pos.x = mouse_pos.x > xrange ? xrange : mouse_pos.x < 0 ? 0 : mouse_pos.x;
+                                        mouse_pos.y = mouse_pos.y > 0 ? 0 : mouse_pos.y < -yrange ? -yrange : mouse_pos.y;
+                                    }
+
+                                    if (move_point == 0 || move_point == 3)
+                                    {
+                                        axis.curve_points[move_point].x = move_point == 0 ? 0f : 1f;
+                                        axis.curve_points[move_point].y = -(mouse_pos.y / yrange);
+                                    }
+                                    else
+                                    {
+                                        axis.curve_points[move_point].x = mouse_pos.x / xrange;
+                                        axis.curve_points[move_point].y = -(mouse_pos.y / yrange);
+                                    }
+                                }
+                                else
+                                {
+                                    move_point = -1;
+                                }
+                            }
+                            // otherwise test if a point should be selected
+                            else
+                            {
+                                Vector2 point_pos = initial_pos;
+                                int point_candidate = -1;
+                                for (int i = 0; i < 4; i++)
+                                {
+                                    point_pos = initial_pos;
+                                    point_pos.x += axis.curve_points[i].x * xrange; // get the current point position
+                                    point_pos.y -= axis.curve_points[i].y * yrange;
+                                    if (TestMouseInRect(point_pos, 20f, 20f)) point_candidate = i; // formerly 15
+                                }
+                                if (Input.GetMouseButton(0) && point_candidate != -1) // left mouse button
+                                {
+                                    move_point = point_candidate;
+                                }
+                            }
+
+                        }
+
+
+                        break;
+                    case MenuSubState.BACK:
+                        if (m_menu_state_timer > 0.25f)
+                        {
+                            MenuManager.ChangeMenuState(((Stack<MenuState>)AccessTools.Field(typeof(MenuManager), "m_back_stack").GetValue(null)).Pop(), true);
+                            AccessTools.Field(typeof(MenuManager), "m_went_back").SetValue(null, true);
+                        }
+                        break;
+                    case MenuSubState.START:
+                        if (m_menu_state_timer > 0.25f)
+                        {
+
+                        }
+                        break;
+                }
+            }
+
+            public static bool TestMouseInRect(Vector2 pos, float x, float y)
+            {
+                if (!GameplayManager.VRActive)
+                {
+                    Rect rect = new Rect(pos.x - x, pos.y - y, x * 2f, y * 2f);
+                    if (rect.Contains(UIManager.m_mouse_pos) || !UIManager.m_menu_use_mouse)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+
+            }
+
+        }
+
+
+        // draws the curve editor
+        [HarmonyPatch(typeof(UIElement), "Draw")]
+        class JoystickCurveEditor_UIElement_Draw
+        {
+            static void Postfix(UIElement __instance)
+            {
+                if (__instance.m_type == Menus.uiAxisCurveEditor && __instance.m_alpha > 0f)
+                    DrawCurveEditorWindow(__instance);
+            }
+
+            static void DrawCurveEditorWindow(UIElement uie)
+            {
+                UIManager.ui_bg_dark = true;
+                uie.DrawMenuBG();
+                Vector2 position = uie.m_position;
+                position.y = UIManager.UI_TOP + 64f;
+                uie.DrawHeaderMedium(Vector2.up * (UIManager.UI_TOP + 30f), Loc.LS("CURVE EDITOR"), 265f);
+                position.y += 20f;
+                uie.DrawMenuSeparator(position);
+                position.y += 40f;
+
+                Controller controller = Controls.m_controllers[MenuManager.m_calibration_current_controller];
+                if (controller.isConnected)
+                {
+                    Vector2 pos = new Vector2(-605f, -270f);
+                    uie.DrawStringSmall("CONTROLLER:", pos, 0.32f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                    pos.x += 95f;
+                    uie.DrawStringSmall(controller.name, pos, 0.45f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                    pos.y += 42f;
+                    pos.x -= 95f;
+                    uie.DrawStringSmall("AXIS:", pos, 0.32f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+                    pos.x += 95f;
+                    uie.DrawStringSmall(MenuManager.m_calibration_current_axis + ": [" + Loc.LSX(controller.m_joystick.AxisElementIdentifiers[MenuManager.m_calibration_current_axis].name + "]"), pos, 0.45f, StringOffset.LEFT, UIManager.m_col_ui1, 1f, -1f);
+
+                    Vector2 initial_pos = new Vector2(0, -22);
+                    int xrange = 500;
+                    int yrange = 500;
+
+                    DrawStatsAxes(uie, initial_pos, xrange, yrange);
+
+                    DrawResponseCurve(initial_pos, xrange, yrange);
+
+                    pos.x += 960f;
+                    pos.y += 386f;
+                    uie.SelectAndDrawItem(Loc.LS("RESET CURVE"), pos, 234, false, 0.47f, 0.6f);
+                    pos.y += 52f;
+                    uie.SelectAndDrawItem(Loc.LS("SET TO LINEAR"), pos, 233, false, 0.47f, 0.6f);
+                }
+
+                position.y = UIManager.UI_BOTTOM - 120f;
+                uie.DrawMenuSeparator(position);
+                position.y += 5f;
+                position.y = UIManager.UI_BOTTOM - 30f;
+                uie.SelectAndDrawItem(Loc.LS("BACK"), position, 100, fade: false);
+            }
+
+
+            private static void DrawStatsAxes(UIElement __instance, Vector2 initial_pos, int xrange, int yrange)
+            {
+                float qyrange = yrange / 4;
+                float qxrange = xrange / 4;
+                Vector2 zero = initial_pos;
+                Color c = UIManager.m_col_ub2;
+                c.a = 1f * 0.75f;
+                zero.y -= qyrange;
+                UIManager.DrawQuadBarHorizontal(zero, 1f, 1f, xrange, c, 4);
+                zero.y += qyrange;
+                UIManager.DrawQuadBarHorizontal(zero, 1f, 1f, xrange, c, 4);
+                zero.y += qyrange;
+                UIManager.DrawQuadBarHorizontal(zero, 1f, 1f, xrange, c, 4);
+                zero.y = initial_pos.y;
+
+                zero.x -= qxrange;
+                UIManager.DrawQuadBarVertical(zero, 1f, 1f, yrange, c, 4);
+                zero.x += qxrange;
+                UIManager.DrawQuadBarVertical(zero, 1f, 1f, yrange, c, 4);
+                zero.x += qxrange;
+                UIManager.DrawQuadBarVertical(zero, 1f, 1f, yrange, c, 4);
+
+                zero.x = initial_pos.x;
+                UIManager.DrawFrameEmptyCenter(zero, 4f, 4f, xrange - 2, yrange - 2, c, 8);
+                c = UIManager.m_col_ui0;
+                c.a = 0.8f;
+
+                zero = initial_pos;
+                zero.x += (yrange / 2) + 15;
+                zero.y -= (yrange / 2) + 15;
+                __instance.DrawStringSmall("[1,1]", zero, 0.4f, StringOffset.RIGHT, UIManager.m_col_ui0, 1f, -1f);
+                zero.x -= yrange + 35;
+                zero.y += yrange + 30;
+                __instance.DrawStringSmall("[0,0]", zero, 0.4f, StringOffset.LEFT, UIManager.m_col_ui0, 1f, -1f);
+            }
+
+            private static void DrawResponseCurve(Vector2 initial_pos, int xrange, int yrange)
+            {
+                int cv = 6222419;
+                Color color = new Color((cv >> 16) / 255f, ((cv >> 8) & 0xff) / 255f, (cv & 0xff) / 255f);
+
+                initial_pos.x -= xrange / 2;
+                initial_pos.y += yrange / 2;
+
+                if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                {
+                    ExtendedConfig.Section_JoystickCurve.Controller.Axis axis = ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis];
+
+                    // draw the curve
+                    Vector2 start = new Vector2(initial_pos.x, initial_pos.y - axis.curve_points[0].y * yrange);
+                    Vector2 end = new Vector2(initial_pos.x + 1 * xrange, initial_pos.y - axis.curve_points[3].y * yrange);
+                    for (float i = 0.02f; i <= 1f; i += 0.02f)
+                    {
+                        end.x = initial_pos.x + CubicBezierAxisForT(i, axis.curve_points[0].x, axis.curve_points[1].x, axis.curve_points[2].x, axis.curve_points[3].x) * xrange;
+                        end.y = initial_pos.y - CubicBezierAxisForT(i, axis.curve_points[0].y, axis.curve_points[1].y, axis.curve_points[2].y, axis.curve_points[3].y) * yrange;
+                        UIManager.DrawQuadCenterLine(start, end, 1f, 0f, color, 4);
+                        start = end;
+                    }
+
+                    // draw deadzone
+                    //UIManager.DrawQuadCenterLine(initial_pos, new Vector2(initial_pos.x + (Controllers.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].deadzone / 200f) * xrange, initial_pos.y), 1f, 0f, Color.red, 4);
+
+                    // draw the lines from p0->p1, p2->p3
+                    start = initial_pos;
+                    start.x += axis.curve_points[0].x * xrange;
+                    start.y -= axis.curve_points[0].y * yrange;
+                    end = initial_pos;
+                    end.x += axis.curve_points[1].x * xrange;
+                    end.y -= axis.curve_points[1].y * yrange;
+                    Vector2 local_start = start, local_end = start;
+                    for (int i = 0; i < 20; i++)
+                    {
+                        local_end = local_start + 4 * ((end - start) / (20 * 7));
+                        UIManager.DrawQuadCenterLine(local_start, local_end, 0.7f, 0f, new Color(255, 204, 153), 4);
+                        local_start = local_end + 3 * ((end - start) / (20 * 7));
+                    }
+                    start = initial_pos;
+                    end = initial_pos;
+                    start.x += axis.curve_points[2].x * xrange;
+                    start.y -= axis.curve_points[2].y * yrange;
+
+                    end.x += axis.curve_points[3].x * xrange;
+                    end.y -= axis.curve_points[3].y * yrange;
+                    local_start = start;
+                    local_end = start;
+                    for (int i = 0; i < 20; i++)
+                    {
+                        local_end = local_start + 4 * ((end - start) / (20 * 7));
+                        UIManager.DrawQuadCenterLine(local_start, local_end, 0.7f, 0f, new Color(255, 204, 153), 4);
+                        local_start = local_end + 3 * ((end - start) / (20 * 7));
+                    }
+
+
+                    // draw blocks around the points
+                    float radius = 7.5f;
+                    for (int i = 0; i < 4; i++)
+                    {
+                        start = initial_pos;
+                        start.x += axis.curve_points[i].x * xrange;
+                        start.y -= axis.curve_points[i].y * yrange;
+                        end = start;
+                        start.x -= radius;
+                        start.y += radius;
+                        end.x -= radius;
+                        end.y -= radius;
+                        UIManager.DrawQuadCenterLine(start, end, 1f, 0f, Color.yellow, 4);
+                        end.x += 2 * radius;
+                        end.y += 2 * radius;
+                        UIManager.DrawQuadCenterLine(start, end, 1f, 0f, Color.yellow, 4);
+                        start.x += 2 * radius;
+                        start.y -= 2 * radius;
+                        UIManager.DrawQuadCenterLine(start, end, 1f, 0f, Color.yellow, 4);
+                        end.x -= 2 * radius;
+                        end.y -= 2 * radius;
+                        UIManager.DrawQuadCenterLine(start, end, 1f, 0f, Color.yellow, 4);
+
+                    }
+                }
+            }
+
+        }
+
+
+        // returns the blended value for t given 4 influencing points along one axis
+        public static float CubicBezierAxisForT(float t, float a0, float a1, float a2, float a3)
+        {
+            return (float)(a0 * Math.Pow((1 - t), 3) + a1 * 3 * t * Math.Pow((1 - t), 2) + a2 * 3 * Math.Pow(t, 2) * (1 - t) + a3 * Math.Pow(t, 3));
+        }
+
+
+        
+
+
+
+        // apply the curve 
+        [HarmonyPatch(typeof(Controller), "GetAxis")]
+        class JoystickCurveEditor_OverloadController_GetAxis
+        {
+            static bool Prefix(ref float __result, Controller __instance, int controller_num, int control_num)
+            {
+
+                float axis_value = __instance.m_joystick.GetAxis(control_num);
+                bool neg = false;
+                if (axis_value < 0f)
+                {
+                    axis_value = axis_value * -1f;
+                    neg = true;
+                }
+                float result = axis_value;
+                ExtendedConfig.Section_JoystickCurve.Controller.Axis a = ExtendedConfig.Section_JoystickCurve.controllers[controller_num].axes[control_num];
+                if (axis_value > Controllers.controllers[controller_num].axes[control_num].deadzone / 200f)
+                {
+                    int i = (int)(axis_value / 0.005f);
+                    
+                    if (i == 0){
+                        result = axis_value / 0.005f * a.curve_lookup[0];
+                    }
+                    else if (i == 200){
+                        result = a.curve_lookup[199] + ((axis_value - 0.995f) / 0.005f * (1f - a.curve_lookup[199]));
+                    }
+                    else{
+                        result = a.curve_lookup[i - 1] + ((axis_value - (i - 1) * 0.005f) / 0.005f * (a.curve_lookup[i] - a.curve_lookup[i - 1]));
+                    }
+
+                }
+
+                if (axis_value > 0.5f)
+                {
+                    TemplateType template_type = Controls.m_controllers[controller_num].m_template_type;
+                    if (template_type != TemplateType.Gamepad)
+                    {
+                        if (template_type == TemplateType.HOTAS)
+                        {
+                            if (Controls.m_last_primary_fire_time + 0.25f < GameplayManager.m_game_time)
+                            {
+                                Controls.m_last_primary_fire_time = GameplayManager.m_game_time;
+                                Controls.m_controller_used_count[3]++;
+                            }
+                        }
+                    }
+                    else if (Controls.m_last_primary_fire_time + 0.25f < GameplayManager.m_game_time)
+                    {
+                        Controls.m_last_primary_fire_time = GameplayManager.m_game_time;
+                        Controls.m_controller_used_count[2]++;
+                    }
+                }
+                __result = result * (neg ? -1f : 1f);
+
+                // todo: dont forget to remove this
+                
+                if (control_num < 100 && control_num > -1)
+                {
+                    DebugOutput.axes[control_num] = new DebugOutput.InputAdjustment
+                    {
+                        controller_num = controller_num,
+                        control_num = control_num,
+                        last_original_input = axis_value,
+                        last_adjusted_input = result
+                    };
+                }
+
+                return false;
+
+            }
+        }
+
+
+    }
+}

--- a/GameMod/JoystickCurveEditor.cs
+++ b/GameMod/JoystickCurveEditor.cs
@@ -172,17 +172,17 @@ namespace GameMod
                                 Controller controller2 = Controls.m_controllers[MenuManager.m_calibration_current_controller];
                                 switch (UIManager.m_menu_selection)
                                 {
-                                    case 233:     // set linear button
-                                        MenuManager.PlaySelectSound(1f);
-                                        if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
-                                        {
+                                   case 233:     // set linear button
+                                       MenuManager.PlaySelectSound(1f);
+                                       if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                                       {
                                             Vector2 start = ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[0];
                                             Vector2 end = ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[3];
                                             ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[1] = new Vector2(0.25f, start.y + 0.25f * (end.y - start.y));
                                             ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[2] = new Vector2(0.75f, start.y + 0.75f * (end.y - start.y));
                                         }
-                                        break;
-                                    case 234:     // reset curve button
+                                         break;
+                                   case 234:     // reset curve button
                                         MenuManager.PlaySelectSound(1f);
                                         if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
                                         {
@@ -190,6 +190,25 @@ namespace GameMod
                                             ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[1] = new Vector2(0.25f, 0.25f);
                                             ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[2] = new Vector2(0.75f, 0.75f);
                                             ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points[3] = new Vector2(1f, 1f);
+                                        }
+                                         break;
+                                    case 235: // apply to all axis
+                                        MenuManager.PlaySelectSound(1f);
+                                        if (MenuManager.m_calibration_current_controller < Controllers.controllers.Count && MenuManager.m_calibration_current_axis < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count)
+                                        {
+                                            ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_lookup = ExtendedConfig.Section_JoystickCurve.GenerateCurveLookupTable(ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points);
+                                            for( int i = 0; i < Controllers.controllers[MenuManager.m_calibration_current_controller].axes.Count; i++)
+                                            {
+                                                if( ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes.Count > i )
+                                                {
+                                                    ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[i].curve_points =  ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].CloneCurvePoints();
+                                                    ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[i].curve_lookup =  ExtendedConfig.Section_JoystickCurve.GenerateCurveLookupTable(ExtendedConfig.Section_JoystickCurve.controllers[MenuManager.m_calibration_current_controller].axes[MenuManager.m_calibration_current_axis].curve_points);
+                                                }
+                                                else
+                                                {
+                                                    Debug.Log("Error while pressing JoystickCurveEditor->[Apply to all Axis] Button: Axis mismatch between Overload.Controls and ExtendedConfig.Section_JoystickCurve");
+                                                }
+                                            }
                                         }
                                         break;
                                     case 100:
@@ -345,10 +364,12 @@ namespace GameMod
                     DrawResponseCurve(initial_pos, xrange, yrange);
 
                     pos.x += 960f;
-                    pos.y += 386f;
+                    pos.y += 334f;
                     uie.SelectAndDrawItem(Loc.LS("RESET CURVE"), pos, 234, false, 0.47f, 0.6f);
                     pos.y += 52f;
                     uie.SelectAndDrawItem(Loc.LS("SET TO LINEAR"), pos, 233, false, 0.47f, 0.6f);
+                    pos.y += 52f;
+                    uie.SelectAndDrawItem(Loc.LS("APPLY TO ALL AXIS"), pos, 235, false, 0.47f, 0.6f);
                 }
 
                 position.y = UIManager.UI_BOTTOM - 120f;
@@ -536,7 +557,7 @@ namespace GameMod
                 }
                 catch( Exception ex )
                 {
-                    Debug.Log(" JoystickCurveEditor_OverloadController_GetAxis: Incorrect Device information: Resetting");
+                    Debug.Log(" JoystickCurveEditor_OverloadController_GetAxis: Incorrect Device information: "+ex);
                     ExtendedConfig.Section_JoystickCurve.SetDefault();
                     return true;
                 }

--- a/GameMod/JoystickCurveEditor.cs
+++ b/GameMod/JoystickCurveEditor.cs
@@ -369,7 +369,7 @@ namespace GameMod
                     pos.y += 52f;
                     uie.SelectAndDrawItem(Loc.LS("SET TO LINEAR"), pos, 233, false, 0.47f, 0.6f);
                     pos.y += 52f;
-                    uie.SelectAndDrawItem(Loc.LS("APPLY TO ALL AXIS"), pos, 235, false, 0.47f, 0.6f);
+                    uie.SelectAndDrawItem(Loc.LS("APPLY TO ALL AXES"), pos, 235, false, 0.47f, 0.6f);
                 }
 
                 position.y = UIManager.UI_BOTTOM - 120f;

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -28,21 +28,21 @@ namespace GameMod
             {
                 miasmic = !miasmic;
                 uConsole.Log("Toggled HUD! current state : " + miasmic);
-                MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
+                MPAutoSelectionUI.MPAutoSelectUI_UIElement_Draw.saveToFile();
             }
 
             private static void CmdTogglePrimary()
             {
                 primarySwapFlag = !primarySwapFlag;
                 uConsole.Log("[AS] Primary weapon swapping: " + primarySwapFlag);
-                MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
+                MPAutoSelectionUI.MPAutoSelectUI_UIElement_Draw.saveToFile();
             }
 
             private static void CmdToggleSecondary()
             {
                 secondarySwapFlag = !secondarySwapFlag;
                 uConsole.Log("[AS] Secondary weapon swapping: " + secondarySwapFlag);
-                MPAutoSelectionUI.DrawMpAutoselectOrderingScreen.saveToFile();
+                MPAutoSelectionUI.MPAutoSelectUI_UIElement_Draw.saveToFile();
             }
         }
 

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -29,21 +29,21 @@ namespace GameMod
             {
                 miasmic = !miasmic;
                 uConsole.Log("Toggled HUD! current state : " + miasmic);
-                MPAutoSelectionUI.MPAutoSelectUI_UIElement_Draw.saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
             }
 
             private static void CmdTogglePrimary()
             {
                 primarySwapFlag = !primarySwapFlag;
                 uConsole.Log("[AS] Primary weapon swapping: " + primarySwapFlag);
-                MPAutoSelectionUI.MPAutoSelectUI_UIElement_Draw.saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
             }
 
             private static void CmdToggleSecondary()
             {
                 secondarySwapFlag = !secondarySwapFlag;
                 uConsole.Log("[AS] Secondary weapon swapping: " + secondarySwapFlag);
-                MPAutoSelectionUI.MPAutoSelectUI_UIElement_Draw.saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
             }
         }
 
@@ -116,190 +116,8 @@ namespace GameMod
         public static void Initialise()
         {
             MenuManager.opt_primary_autoswitch = 0;
-            if (File.Exists(textFile))
-            {
-                readContent();
-            }
-            else
-            {
-
-                Debug.Log("-AUTOSELECT- [ERROR] File does not exist. Creating default priority list");
-                createDefaultPriorityFile();
-                readContent();
-            }
             isInitialised = true;
         }
-
-        private static void createDefaultPriorityFile()
-        {
-            using (StreamWriter sw = File.CreateText(textFile))
-            {
-                sw.WriteLine("THUNDERBOLT");
-                sw.WriteLine("CYCLONE");
-                sw.WriteLine("DRILLER");
-                sw.WriteLine("IMPULSE");
-                sw.WriteLine("FLAK");
-                sw.WriteLine("CRUSHER");
-                sw.WriteLine("LANCER");
-                sw.WriteLine("REFLEX");
-                sw.WriteLine("DEVASTATOR");
-                sw.WriteLine("NOVA");
-                sw.WriteLine("TIMEBOMB");
-                sw.WriteLine("HUNTER");
-                sw.WriteLine("VORTEX");
-                sw.WriteLine("FALCON");
-                sw.WriteLine("MISSILE_POD");
-                sw.WriteLine("CREEPER");
-                sw.WriteLine(PrimaryNeverSelect[0]);
-                sw.WriteLine(PrimaryNeverSelect[1]);
-                sw.WriteLine(PrimaryNeverSelect[2]);
-                sw.WriteLine(PrimaryNeverSelect[3]);
-                sw.WriteLine(PrimaryNeverSelect[4]);
-                sw.WriteLine(PrimaryNeverSelect[5]);
-                sw.WriteLine(PrimaryNeverSelect[6]);
-                sw.WriteLine(PrimaryNeverSelect[7]);
-                sw.WriteLine(SecondaryNeverSelect[0]);
-                sw.WriteLine(SecondaryNeverSelect[1]);
-                sw.WriteLine(SecondaryNeverSelect[2]);
-                sw.WriteLine(SecondaryNeverSelect[3]);
-                sw.WriteLine(SecondaryNeverSelect[4]);
-                sw.WriteLine(SecondaryNeverSelect[5]);
-                sw.WriteLine(SecondaryNeverSelect[6]);
-                sw.WriteLine(SecondaryNeverSelect[7]);
-                sw.WriteLine(primarySwapFlag);
-                sw.WriteLine(secondarySwapFlag);
-                sw.WriteLine(swapWhileFiring);
-                sw.WriteLine(dontAutoselectAfterFiring);
-                sw.WriteLine(zorc);
-                sw.WriteLine(miasmic);
-            }
-        }
-
-        private static bool stringToBool(string b)
-        {
-            if (b == "True")
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        private static void readContent()
-        {
-            using (StreamReader file = new StreamReader(textFile))
-            {
-                int counter = 0;
-                string ln;
-
-
-
-                while ((ln = file.ReadLine()) != null)
-                {
-                    /// Contains the priorities of the primary weapons
-                    if (counter < 8)
-                    {
-                        if (ln == "THUNDERBOLT" | ln == "IMPULSE" | ln == "CYCLONE" | ln == "DRILLER" | ln == "LANCER" | ln == "REFLEX" | ln == "FLAK" | ln == "CRUSHER")
-                        {
-                            PrimaryPriorityArray[counter] = ln;
-                        }
-                        else
-                        {
-                            Debug.Log("-AUTOORDER- [ERROR](1) unexpected line content -> (content: " + ln + " )");
-                            return;
-                        }
-
-                    }
-
-                    /// Contains the priorities of the secondary weapons
-                    else if (counter < 16)
-                    {
-                        if (ln == "DEVASTATOR" | ln == "TIMEBOMB" | ln == "VORTEX" | ln == "NOVA" | ln == "HUNTER" | ln == "FALCON" | ln == "CREEPER" | ln == "MISSILE_POD")
-                        {
-                            SecondaryPriorityArray[counter - 8] = ln;
-                        }
-                        else
-                        {
-                            Debug.Log("-AUTOORDER- [ERROR](2) unexpected line content -> (content: " + ln + " )");
-                            return;
-                        }
-                    }
-
-                    /// Contains true/false whether primary priorities are neverselected
-                    else if (counter < 24)
-                    {
-                        if (ln == "True" || ln == "False")
-                        {
-                            PrimaryNeverSelect[counter - 16] = stringToBool(ln);
-                        }
-                        else
-                        {
-                            for (int i = 0; i < 8; i++)
-                            {
-                                PrimaryNeverSelect[i] = false;
-                            }
-                        }
-                    }
-                    /// Contains true/false whether secondary priorities are neverselected
-                    else if (counter < 32)
-                    {
-                        if (ln == "True" || ln == "False")
-                        {
-                            SecondaryNeverSelect[counter - 24] = stringToBool(ln);
-                        }
-                        else
-                        {
-                            for (int i = 0; i < 8; i++)
-                            {
-                                SecondaryNeverSelect[i] = false;
-                            }
-                        }
-                    }
-                    else if (counter == 32)
-                    {
-                        if (ln == "True" || ln == "False") { primarySwapFlag = stringToBool(ln); }
-                    }
-                    else if (counter == 33)
-                    {
-                        if (ln == "True" || ln == "False") { secondarySwapFlag = stringToBool(ln); }
-                    }
-                    else if (counter == 34)
-                    {
-                        if (ln == "True" || ln == "False") { swapWhileFiring = stringToBool(ln); }
-                    }
-                    else if (counter == 35)
-                    {
-                        if (ln == "True" || ln == "False") { dontAutoselectAfterFiring = stringToBool(ln); }
-                    }
-                    else if (counter == 36)
-                    {
-                        if (ln == "True" || ln == "False") { zorc = stringToBool(ln); }
-                    }
-                    else if (counter == 37)
-                    {
-                        if (ln == "True" || ln == "False") { miasmic = stringToBool(ln); }
-                    }
-
-                    else
-                    {
-                        Debug.Log("-AUTOORDER- [ERROR](3) unexpected line content -> (content: " + ln + " : " + counter + " )");
-
-                        return;
-                    }
-                    counter++;
-                }
-                file.Close();
-
-            }
-        }
-
-
-
-
-
-
 
 
 

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -12,7 +12,7 @@ namespace GameMod
 {
     class MPAutoSelection
     {
-
+        
         [HarmonyPatch(typeof(GameManager), "Start")]
         internal class CommandsAndInitialisationPatch
         {

--- a/GameMod/MPAutoSelection.cs
+++ b/GameMod/MPAutoSelection.cs
@@ -1044,4 +1044,13 @@ namespace GameMod
             }
         }
     }
+
+    [HarmonyPatch(typeof(MenuManager), "LoadPreferences")]
+    class MPAutoSelection_MenuManager_LoadPreferences
+    {
+        public static void Postfix()
+        {
+            MenuManager.opt_primary_autoswitch = 0;
+        }
+    }
 }

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -649,7 +649,7 @@ namespace GameMod
             private static Color UIColorPrimaries;
             private static Color UIColorSecondaries;
         }
-
+        
        
     }
 }

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -28,12 +28,16 @@ namespace GameMod
 
                     if (state == 0 && codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "CONTROL OPTIONS - ADVANCED")
                     {
+                        // remove the 'PRIMARY AUTOSELECT' option
+                        codes.RemoveRange(i + 17, 11);
+
+                        // add the autoselect menu button
                         var newCodes = new[] {
                             new CodeInstruction(OpCodes.Ldarg_0),
                             new CodeInstruction(OpCodes.Ldloca, 0),
                             new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPAutoSelectionUI_UIElement_DrawControlsMenu), "DrawAutoselectMenuOption"))
                         };
-                        codes.InsertRange(i + 16, newCodes);
+                        codes.InsertRange(i + 17, newCodes);
                         state++;
                     }
                     // make some space

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -205,7 +205,7 @@ namespace GameMod
                                                 MenuManager.opt_primary_autoswitch = 0;
                                                 SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
                                             }
-                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                            ExtendedConfig.Section_AutoSelect.Set(true);
                                         }
                                         break;
                                     case 2102:
@@ -221,7 +221,7 @@ namespace GameMod
                                                 MPAutoSelection.secondarySwapFlag = true;
                                                 SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
                                             }
-                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                            ExtendedConfig.Section_AutoSelect.Set(true);
                                         }
                                         break;
                                     case 2103:
@@ -238,7 +238,7 @@ namespace GameMod
                                                 MenuManager.opt_primary_autoswitch = 0;
                                                 SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
                                             }
-                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                            ExtendedConfig.Section_AutoSelect.Set(true);
                                         }
                                         break;
                                     case 2104:
@@ -254,7 +254,7 @@ namespace GameMod
                                                 MPAutoSelection.zorc = true;
                                                 SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
                                             }
-                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                            ExtendedConfig.Section_AutoSelect.Set(true);
                                         }
                                         break;
                                     case 2105:
@@ -270,7 +270,7 @@ namespace GameMod
                                                 MPAutoSelection.dontAutoselectAfterFiring = true;
                                                 SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
                                             }
-                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                            ExtendedConfig.Section_AutoSelect.Set(true);
                                         }
                                         break;
                                     case 2106:
@@ -286,7 +286,7 @@ namespace GameMod
                                                 MPAutoSelection.swapWhileFiring = true;
                                                 SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
                                             }
-                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                            ExtendedConfig.Section_AutoSelect.Set(true);
                                         }
                                         break;
                                 }
@@ -301,7 +301,6 @@ namespace GameMod
                     case MenuSubState.BACK:
                         if (m_menu_state_timer > 0.25f)
                         {
-                            MPAutoSelectUI_UIElement_Draw.isInitialised = false;
                             MenuManager.ChangeMenuState(((Stack<MenuState>)AccessTools.Field(typeof(MenuManager), "m_back_stack").GetValue(null)).Pop(), true);
                             AccessTools.Field(typeof(MenuManager), "m_went_back").SetValue(null, true);
                         }
@@ -328,7 +327,7 @@ namespace GameMod
                 {
                     SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
                 }
-                MPAutoSelectUI_UIElement_Draw.saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
             }
 
             private static void doNeverSelectStuffForSecondary(int i)
@@ -342,7 +341,7 @@ namespace GameMod
                 {
                     SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
                 }
-                MPAutoSelectUI_UIElement_Draw.saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
             }
 
             private static void doSelectedStuffForPrimary(int i)
@@ -400,11 +399,6 @@ namespace GameMod
             {
                 if (__instance.m_type == Menus.uiAutoSelect)
                 {
-                    if (isInitialised == false)
-                    {
-                        Initialise();
-                        isInitialised = true;
-                    }
                     DrawAutoSelectWindow(__instance);
                 }   
             }
@@ -464,7 +458,7 @@ namespace GameMod
                     position.x -= 150f;
                     uie.SelectAndDrawItem(!MPAutoSelection.PrimaryNeverSelect[i] ? "+" : "-", position, 2000 + i, false, 0.022f, 1f);
                     position.x += 150f;
-                    uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);
+                    uie.SelectAndDrawHalfItem(MPAutoSelection.PrimaryPriorityArray[i], position, 1720 + i, false);
                     position.y += 50f;
 
 
@@ -481,7 +475,7 @@ namespace GameMod
                     position2.x += 150f;
                     uie.SelectAndDrawItem((!MPAutoSelection.SecondaryNeverSelect[i] ? "+" : "-"), position2, 2010 + i, false, 0.022f, 1f);
                     position2.x -= 150f;
-                    uie.SelectAndDrawHalfItem(Secondary[i], position2, 1728 + i, false);
+                    uie.SelectAndDrawHalfItem(MPAutoSelection.SecondaryPriorityArray[i], position2, 1728 + i, false);
                     position2.y += 50f;
                 }
 
@@ -527,26 +521,7 @@ namespace GameMod
             }
 
 
-            public static void Initialise()
-            {
-                Primary[0] = MPAutoSelection.PrimaryPriorityArray[0];
-                Primary[1] = MPAutoSelection.PrimaryPriorityArray[1];
-                Primary[2] = MPAutoSelection.PrimaryPriorityArray[2];
-                Primary[3] = MPAutoSelection.PrimaryPriorityArray[3];
-                Primary[4] = MPAutoSelection.PrimaryPriorityArray[4];
-                Primary[5] = MPAutoSelection.PrimaryPriorityArray[5];
-                Primary[6] = MPAutoSelection.PrimaryPriorityArray[6];
-                Primary[7] = MPAutoSelection.PrimaryPriorityArray[7];
-
-                Secondary[0] = MPAutoSelection.SecondaryPriorityArray[0];
-                Secondary[1] = MPAutoSelection.SecondaryPriorityArray[1];
-                Secondary[2] = MPAutoSelection.SecondaryPriorityArray[2];
-                Secondary[3] = MPAutoSelection.SecondaryPriorityArray[3];
-                Secondary[4] = MPAutoSelection.SecondaryPriorityArray[4];
-                Secondary[5] = MPAutoSelection.SecondaryPriorityArray[5];
-                Secondary[6] = MPAutoSelection.SecondaryPriorityArray[6];
-                Secondary[7] = MPAutoSelection.SecondaryPriorityArray[7];
-            }
+            
 
             public static int returnPrimarySelected()
             {
@@ -590,16 +565,16 @@ namespace GameMod
                         break;
                     }
                 }
-                string temp = Primary[selection[0]];
-                Primary[selection[0]] = Primary[selection[1]];
-                Primary[selection[1]] = temp;
+                string temp = MPAutoSelection.PrimaryPriorityArray[selection[0]];
+                MPAutoSelection.PrimaryPriorityArray[selection[0]] = MPAutoSelection.PrimaryPriorityArray[selection[1]];
+                MPAutoSelection.PrimaryPriorityArray[selection[1]] = temp;
 
                 isPrimarySelected[selection[0]] = false;
                 isPrimarySelected[selection[1]] = false;
                 MPAutoSelection.PrimaryNeverSelect[selection[0]] = false;
                 MPAutoSelection.PrimaryNeverSelect[selection[1]] = false;
 
-                saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
                 MPAutoSelection.Initialise();
             }
 
@@ -619,63 +594,19 @@ namespace GameMod
                         break;
                     }
                 }
-                string temp = Secondary[selection[0]];
-                Secondary[selection[0]] = Secondary[selection[1]];
-                Secondary[selection[1]] = temp;
+                string temp = MPAutoSelection.SecondaryPriorityArray[selection[0]];
+                MPAutoSelection.SecondaryPriorityArray[selection[0]] = MPAutoSelection.SecondaryPriorityArray[selection[1]];
+                MPAutoSelection.SecondaryPriorityArray[selection[1]] = temp;
 
                 isSecondarySelected[selection[0]] = false;
                 isSecondarySelected[selection[1]] = false;
                 MPAutoSelection.SecondaryNeverSelect[selection[0]] = false;
                 MPAutoSelection.SecondaryNeverSelect[selection[1]] = false;
 
-                saveToFile();
+                ExtendedConfig.Section_AutoSelect.Set(true);
                 MPAutoSelection.Initialise();
             }
 
-            public static void saveToFile()
-            {
-                using (StreamWriter sw = File.CreateText(MPAutoSelection.textFile))
-                {
-                    sw.WriteLine(Primary[0]);
-                    sw.WriteLine(Primary[1]);
-                    sw.WriteLine(Primary[2]);
-                    sw.WriteLine(Primary[3]);
-                    sw.WriteLine(Primary[4]);
-                    sw.WriteLine(Primary[5]);
-                    sw.WriteLine(Primary[6]);
-                    sw.WriteLine(Primary[7]);
-                    sw.WriteLine(Secondary[0]);
-                    sw.WriteLine(Secondary[1]);
-                    sw.WriteLine(Secondary[2]);
-                    sw.WriteLine(Secondary[3]);
-                    sw.WriteLine(Secondary[4]);
-                    sw.WriteLine(Secondary[5]);
-                    sw.WriteLine(Secondary[6]);
-                    sw.WriteLine(Secondary[7]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[0]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[1]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[2]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[3]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[4]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[5]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[6]);
-                    sw.WriteLine(MPAutoSelection.PrimaryNeverSelect[7]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[0]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[1]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[2]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[3]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[4]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[5]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[6]);
-                    sw.WriteLine(MPAutoSelection.SecondaryNeverSelect[7]);
-                    sw.WriteLine(MPAutoSelection.primarySwapFlag);
-                    sw.WriteLine(MPAutoSelection.secondarySwapFlag);
-                    sw.WriteLine(MPAutoSelection.swapWhileFiring);
-                    sw.WriteLine(MPAutoSelection.dontAutoselectAfterFiring);
-                    sw.WriteLine(MPAutoSelection.zorc);
-                    sw.WriteLine(MPAutoSelection.miasmic);
-                }
-            }
 
             public static string selectionToDescription(int n)
             {
@@ -711,28 +642,6 @@ namespace GameMod
                 }
             }
 
-            public static bool isInitialised = false;
-
-            public static string[] Primary = {
-                MPAutoSelection.PrimaryPriorityArray[0],
-                MPAutoSelection.PrimaryPriorityArray[1],
-                MPAutoSelection.PrimaryPriorityArray[2],
-                MPAutoSelection.PrimaryPriorityArray[3],
-                MPAutoSelection.PrimaryPriorityArray[4],
-                MPAutoSelection.PrimaryPriorityArray[5],
-                MPAutoSelection.PrimaryPriorityArray[6],
-                MPAutoSelection.PrimaryPriorityArray[7],
-            };
-            public static string[] Secondary = {
-                MPAutoSelection.SecondaryPriorityArray[0],
-                MPAutoSelection.SecondaryPriorityArray[1],
-                MPAutoSelection.SecondaryPriorityArray[2],
-                MPAutoSelection.SecondaryPriorityArray[3],
-                MPAutoSelection.SecondaryPriorityArray[4],
-                MPAutoSelection.SecondaryPriorityArray[5],
-                MPAutoSelection.SecondaryPriorityArray[6],
-                MPAutoSelection.SecondaryPriorityArray[7]
-            };
             public static bool[] isPrimarySelected = new bool[8];
             public static bool[] isSecondarySelected = new bool[8];
 

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -16,7 +16,7 @@ namespace GameMod
             private static void DrawAutoselectMenuOption(UIElement uie, ref Vector2 position)
             {
                 uie.SelectAndDrawItem(Loc.LS("CONFIGURE AUTOSELECT"), position, 121, false, 1f, 0.75f);
-                position.y += 55f;
+                //position.y += 55f;
             }
 
             static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -40,6 +40,7 @@ namespace GameMod
                         codes.InsertRange(i + 17, newCodes);
                         state++;
                     }
+
                     // make some space
                     if (state > 0 && state < 10 && codes[i].opcode == OpCodes.Ldc_R4 && (float)codes[i].operand == 62f)
                     {

--- a/GameMod/MPAutoSelectionUI.cs
+++ b/GameMod/MPAutoSelectionUI.cs
@@ -1,284 +1,313 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Reflection.Emit;
 using Harmony;
 using Overload;
 using UnityEngine;
 
-namespace GameMod {
+namespace GameMod
+{
     class MPAutoSelectionUI
     {
-        // Menu manager
-        [HarmonyPatch(typeof(MenuManager), "MpCustomizeUpdate")]
-        class MpCustomizeMenuLogic
+        // Adds the 'CONFIGURE AUTOSELECT' Option as the Entrypoint for the Autoselect menu under 'Options/Control Options/'
+        [HarmonyPatch(typeof(UIElement), "DrawControlsMenu")]
+        internal class MPAutoSelectionUI_UIElement_DrawControlsMenu
         {
-            static IEnumerable<CodeInstruction> Transpiler(ILGenerator ilGen, IEnumerable<CodeInstruction> codes)
+            private static void DrawAutoselectMenuOption(UIElement uie, ref Vector2 position)
             {
-                var uiManager_m_menu_selection_Field = AccessTools.Field(typeof(UIManager), "m_menu_selection");
+                uie.SelectAndDrawItem(Loc.LS("CONFIGURE AUTOSELECT"), position, 121, false, 1f, 0.75f);
+                position.y += 55f;
+            }
 
-                var twoCount = 0;
-                var threeCount = 0;
-                foreach (var code in codes)
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                var codes = new List<CodeInstruction>(instructions);
+                int state = 0;
+                for (int i = 0; i < codes.Count; i++)
                 {
-                    // Allow all 4 menu options to be scrolled through.
-                    if (code.opcode == OpCodes.Ldc_I4_2)
+
+                    if (state == 0 && codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "CONTROL OPTIONS - ADVANCED")
                     {
-                        twoCount++;
-                        if (twoCount == 1)
-                        {
-                            code.opcode = OpCodes.Ldc_I4_3;
-                        }
+                        var newCodes = new[] {
+                            new CodeInstruction(OpCodes.Ldarg_0),
+                            new CodeInstruction(OpCodes.Ldloca, 0),
+                            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPAutoSelectionUI_UIElement_DrawControlsMenu), "DrawAutoselectMenuOption"))
+                        };
+                        codes.InsertRange(i + 16, newCodes);
+                        state++;
                     }
-                    else if (code.opcode == OpCodes.Ldc_I4_3)
+                    // make some space
+                    if (state > 0 && state < 10 && codes[i].opcode == OpCodes.Ldc_R4 && (float)codes[i].operand == 62f)
                     {
-                        threeCount++;
-                        if (threeCount == 2 || threeCount == 3)
-                        {
-                            code.opcode = OpCodes.Ldc_I4_4;
-                        }
+                        codes[i].operand = 55f;
                     }
 
-                    // Prevent profile corruption when selecting autoselect options.  Adds a "case 203" to several switch statements in the function.
-                    if (code.opcode == OpCodes.Ldsfld && code.operand == uiManager_m_menu_selection_Field)
+                    if (state < 10 && codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "INVERT SLIDE MODIFIER Y")
                     {
-                        if (code.labels.Count == 3)
-                        {
-                            Label l = ilGen.DefineLabel();
-                            code.labels.Add(l);
-                        }
+                        state = 10;
                     }
-                    yield return code;
                 }
+                return codes;
+            }
+        }
+
+
+        // Changes the menu state if the "CONFIGURE AUTOSELECT" Button gets pressed
+        [HarmonyPatch(typeof(MenuManager), "ControlsOptionsUpdate")]
+        class MPAutoSelectionUI_MenuManager_ControlsOptionsUpdate
+        {
+            static void Postfix()
+            {
+                if (UIManager.PushedSelect(100) || (MenuManager.option_dir && UIManager.PushedDir()) || UIManager.SliderMouseDown())
+                {
+                    switch (UIManager.m_menu_selection)
+                    {
+                        case 121:
+                            MenuManager.ChangeMenuState(Menus.msAutoSelect, false);
+                            UIManager.DestroyAll(false);
+                            MenuManager.PlaySelectSound(1f);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+
+        // Handles the menu logic of the added buttons
+        [HarmonyPatch(typeof(MenuManager), "Update")]
+        class MPAutoSelectionUI_MenuManager_Update
+        {
+
+            private static void Postfix(ref float ___m_menu_state_timer)
+            {
+                if (MenuManager.m_menu_state == Menus.msAutoSelect)
+                    AutoSelectUpdate(ref ___m_menu_state_timer);
             }
 
             public static int selected;
             public static int selected2;
-            public static int loadout1LastTick;
-            public static int loadout2LastTick;
-
-            public static void Postfix()
+            private static void AutoSelectUpdate(ref float m_menu_state_timer)
             {
-                selected = DrawMpAutoselectOrderingScreen.returnPrimarySelected();
-                selected2 = DrawMpAutoselectOrderingScreen.returnSecondarySelected();
+                selected = MPAutoSelectUI_UIElement_Draw.returnPrimarySelected();
+                selected2 = MPAutoSelectUI_UIElement_Draw.returnSecondarySelected();
+                UIManager.MouseSelectUpdate();
                 switch (MenuManager.m_menu_sub_state)
                 {
+                    case MenuSubState.INIT:
+                        if (m_menu_state_timer > 0.25f)
+                        {
+                            UIManager.CreateUIElement(UIManager.SCREEN_CENTER, 7000, Menus.uiAutoSelect);
+                            MenuManager.m_menu_sub_state = MenuSubState.ACTIVE;
+                            m_menu_state_timer = 0f;
+                            MenuManager.SetDefaultSelection(0);
+                        }
+                        break;
+
                     case MenuSubState.ACTIVE:
-                        if (MenuManager.m_menu_micro_state == 3)
+                        UIManager.ControllerMenu();
+                        Controls.m_disable_menu_letter_keys = false;
+
+                        if (m_menu_state_timer > 0.25f)
                         {
-                            switch (UIManager.m_menu_selection)
+                            if (UIManager.PushedSelect(100) || (MenuManager.option_dir && UIManager.PushedDir() || UIManager.SliderMouseDown()))
                             {
-                                case 200:
-                                case 201:
-                                case 202:
-                                case 203:
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        MenuManager.m_menu_micro_state = UIManager.m_menu_selection - 200;
-                                        MenuManager.UIPulse(1f);
-                                        GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
-                                    }
-                                    break;
+                                MenuManager.MaybeReverseOption();
+                                switch (UIManager.m_menu_selection)
+                                {
 
-                                // Triggers Swap Logic for the Primary Weapon Buttons
-                                case 1720:
-                                case 1721:
-                                case 1722:
-                                case 1723:
-                                case 1724:
-                                case 1725:
-                                case 1726:
-                                case 1727: // int nwhen (MenuManager.m_menu_micro_state > 1719 && MenuManager.m_menu_micro_state <= 1727):
-                                    if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(UIManager.m_menu_selection - 1720);
-                                    break;
-
-
-                                // Triggers Swap Logic for the Secondary Weapon Buttons
-                                case 1728:
-                                case 1729:
-                                case 1730:
-                                case 1731:
-                                case 1732:
-                                case 1733:
-                                case 1734:
-                                case 1735:
-                                    if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(UIManager.m_menu_selection - 1728);
-                                    break;
-
-                                // Triggers Neverselect Logic for the Primary Buttons
-                                case 2000:
-                                case 2001:
-                                case 2002:
-                                case 2003:
-                                case 2004:
-                                case 2005:
-                                case 2006:
-                                case 2007:
-                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(UIManager.m_menu_selection - 2000);
-                                    break;
-
-                                // Triggers Neverselect Logic for the Secondary Buttons
-                                case 2010:
-                                case 2011:
-                                case 2012:
-                                case 2013:
-                                case 2014:
-                                case 2015:
-                                case 2016:
-                                case 2017:
-                                    if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(UIManager.m_menu_selection - 2010);
-                                    break;
-
-                                case 2100:
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        if (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag)
-                                        {
-                                            MPAutoSelection.primarySwapFlag = false;
-                                            MPAutoSelection.secondarySwapFlag = false;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
-                                        }
-                                        else
-                                        {
-                                            MPAutoSelection.primarySwapFlag = true;
-                                            MPAutoSelection.secondarySwapFlag = true;
-                                            MenuManager.opt_primary_autoswitch = 0;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
-                                        }
-                                        DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
-                                    break;
-                                case 2102:
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        if (MPAutoSelection.secondarySwapFlag)
-                                        {
-                                            MPAutoSelection.secondarySwapFlag = false;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
-                                        }
-                                        else
-                                        {
-                                            MPAutoSelection.secondarySwapFlag = true;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
-                                        }
-                                        DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
-                                    break;
-                                case 2103:
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        if (MPAutoSelection.primarySwapFlag)
-                                        {
-                                            MPAutoSelection.primarySwapFlag = false;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
-                                        }
-                                        else
-                                        {
-                                            MPAutoSelection.primarySwapFlag = true;
-                                            MenuManager.opt_primary_autoswitch = 0;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
-                                        }
-                                        DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
-                                    break;
-                                case 2104: //
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        if (MPAutoSelection.zorc)
-                                        {
-                                            MPAutoSelection.zorc = false;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
-                                        }
-                                        else
-                                        {
-                                            MPAutoSelection.zorc = true;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
-                                        }
-                                        DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
-                                    break;
-                                case 2105: //
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        if (MPAutoSelection.dontAutoselectAfterFiring)
-                                        {
-                                            MPAutoSelection.dontAutoselectAfterFiring = false;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
-                                        }
-                                        else
-                                        {
-                                            MPAutoSelection.dontAutoselectAfterFiring = true;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
-                                        }
-                                        DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
-                                    break;
-                                case 2106: //
-                                    if (UIManager.PushedSelect(100))
-                                    {
-                                        if (MPAutoSelection.swapWhileFiring)
-                                        {
-                                            MPAutoSelection.swapWhileFiring = false;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
-                                        }
-                                        else
-                                        {
-                                            MPAutoSelection.swapWhileFiring = true;
-                                            SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
-                                        }
-                                        DrawMpAutoselectOrderingScreen.saveToFile();
-                                    }
-                                    break;
-
-
-
-                                default:
-                                    if (UIManager.PushedSelect(100) && UIManager.m_menu_selection == 100)
-                                    {
-                                        uConsole.Log("Definitly 203 " + Player.Mp_loadout1 + " : " + Player.Mp_loadout2);
-                                        UIManager.DestroyAll(false);
+                                    case 100:
                                         MenuManager.PlaySelectSound(1f);
-                                        if (MPAutoSelection.isCurrentlyInLobby)
+                                        m_menu_state_timer = 0f;
+                                        UIManager.DestroyAll(false);
+                                        MenuManager.m_menu_state = 0;
+                                        MenuManager.m_menu_micro_state = 0;
+                                        MenuManager.m_menu_sub_state = MenuSubState.BACK;
+                                        break;
+                                    case 200:
+                                    case 201:
+                                    case 202:
+                                    case 203:
+                                        if (UIManager.PushedSelect(100))
                                         {
-                                            MenuManager.ChangeMenuState(MenuState.MP_PRE_MATCH_MENU, false);
-
+                                            MenuManager.m_menu_micro_state = UIManager.m_menu_selection - 200;
+                                            MenuManager.UIPulse(1f);
+                                            GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                                         }
-                                        else
+                                        break;
+
+                                    // Triggers Swap Logic for the Primary Weapon Buttons
+                                    case 1720:
+                                    case 1721:
+                                    case 1722:
+                                    case 1723:
+                                    case 1724:
+                                    case 1725:
+                                    case 1726:
+                                    case 1727: // int nwhen (MenuManager.m_menu_micro_state > 1719 && MenuManager.m_menu_micro_state <= 1727):
+                                        if (UIManager.PushedSelect(100)) doSelectedStuffForPrimary(UIManager.m_menu_selection - 1720);
+                                        break;
+
+
+                                    // Triggers Swap Logic for the Secondary Weapon Buttons
+                                    case 1728:
+                                    case 1729:
+                                    case 1730:
+                                    case 1731:
+                                    case 1732:
+                                    case 1733:
+                                    case 1734:
+                                    case 1735:
+                                        if (UIManager.PushedSelect(100)) doSelectedStuffForSecondary(UIManager.m_menu_selection - 1728);
+                                        break;
+
+                                    // Triggers Neverselect Logic for the Primary Buttons
+                                    case 2000:
+                                    case 2001:
+                                    case 2002:
+                                    case 2003:
+                                    case 2004:
+                                    case 2005:
+                                    case 2006:
+                                    case 2007:
+                                        if (UIManager.PushedSelect(100)) doNeverSelectStuffForPrimary(UIManager.m_menu_selection - 2000);
+                                        break;
+
+                                    // Triggers Neverselect Logic for the Secondary Buttons
+                                    case 2010:
+                                    case 2011:
+                                    case 2012:
+                                    case 2013:
+                                    case 2014:
+                                    case 2015:
+                                    case 2016:
+                                    case 2017:
+                                        if (UIManager.PushedSelect(100)) doNeverSelectStuffForSecondary(UIManager.m_menu_selection - 2010);
+                                        break;
+
+                                    case 2100:
+                                        if (UIManager.PushedSelect(100))
                                         {
-                                            MenuManager.ChangeMenuState(MenuState.MP_MENU, false);
+                                            if (MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag)
+                                            {
+                                                MPAutoSelection.primarySwapFlag = false;
+                                                MPAutoSelection.secondarySwapFlag = false;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                                            }
+                                            else
+                                            {
+                                                MPAutoSelection.primarySwapFlag = true;
+                                                MPAutoSelection.secondarySwapFlag = true;
+                                                MenuManager.opt_primary_autoswitch = 0;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                                            }
+                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
                                         }
-                                        DrawMpAutoselectOrderingScreen.isInitialised = false;
-
-                                    }
-                                    break;
-
+                                        break;
+                                    case 2102:
+                                        if (UIManager.PushedSelect(100))
+                                        {
+                                            if (MPAutoSelection.secondarySwapFlag)
+                                            {
+                                                MPAutoSelection.secondarySwapFlag = false;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                                            }
+                                            else
+                                            {
+                                                MPAutoSelection.secondarySwapFlag = true;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                                            }
+                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                        }
+                                        break;
+                                    case 2103:
+                                        if (UIManager.PushedSelect(100))
+                                        {
+                                            if (MPAutoSelection.primarySwapFlag)
+                                            {
+                                                MPAutoSelection.primarySwapFlag = false;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                                            }
+                                            else
+                                            {
+                                                MPAutoSelection.primarySwapFlag = true;
+                                                MenuManager.opt_primary_autoswitch = 0;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                                            }
+                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                        }
+                                        break;
+                                    case 2104:
+                                        if (UIManager.PushedSelect(100))
+                                        {
+                                            if (MPAutoSelection.zorc)
+                                            {
+                                                MPAutoSelection.zorc = false;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                                            }
+                                            else
+                                            {
+                                                MPAutoSelection.zorc = true;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                                            }
+                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                        }
+                                        break;
+                                    case 2105:
+                                        if (UIManager.PushedSelect(100))
+                                        {
+                                            if (MPAutoSelection.dontAutoselectAfterFiring)
+                                            {
+                                                MPAutoSelection.dontAutoselectAfterFiring = false;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                                            }
+                                            else
+                                            {
+                                                MPAutoSelection.dontAutoselectAfterFiring = true;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                                            }
+                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                        }
+                                        break;
+                                    case 2106:
+                                        if (UIManager.PushedSelect(100))
+                                        {
+                                            if (MPAutoSelection.swapWhileFiring)
+                                            {
+                                                MPAutoSelection.swapWhileFiring = false;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
+                                            }
+                                            else
+                                            {
+                                                MPAutoSelection.swapWhileFiring = true;
+                                                SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_picker, 0.8f, 0f, 0f, false);
+                                            }
+                                            MPAutoSelectUI_UIElement_Draw.saveToFile();
+                                        }
+                                        break;
+                                }
                             }
+
+
+
+
                         }
-                        else
+                        break;
+
+                    case MenuSubState.BACK:
+                        if (m_menu_state_timer > 0.25f)
                         {
-                            //uConsole.Log("NOT 203 "+Player.Mp_loadout1 + " : " + Player.Mp_loadout2);
-                            if (Player.Mp_loadout1 == 203 || Player.Mp_loadout2 == 203)
-                            {
-                                Player.Mp_loadout1 = loadout1LastTick;
-                                Player.Mp_loadout2 = loadout2LastTick;
-                            }
-                            else
-                            {
-                                loadout1LastTick = Player.Mp_loadout1;
-                                loadout2LastTick = Player.Mp_loadout2;
-                            }
-                            if (UIManager.PushedSelect(100) && UIManager.m_menu_selection == 203)
-                            {
-                                //MenuManager.SetDefaultSelection(-1);
-                                MenuManager.m_menu_micro_state = 3;
-                                MenuManager.UIPulse(1f);
-                                GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
-                            }
+                            MPAutoSelectUI_UIElement_Draw.isInitialised = false;
+                            MenuManager.ChangeMenuState(((Stack<MenuState>)AccessTools.Field(typeof(MenuManager), "m_back_stack").GetValue(null)).Pop(), true);
+                            AccessTools.Field(typeof(MenuManager), "m_went_back").SetValue(null, true);
+                        }
+                        break;
+
+                    case MenuSubState.START:
+                        if (m_menu_state_timer > 0.25f)
+                        {
 
                         }
-
-
-
                         break;
                 }
             }
@@ -295,7 +324,7 @@ namespace GameMod {
                 {
                     SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
                 }
-                DrawMpAutoselectOrderingScreen.saveToFile();
+                MPAutoSelectUI_UIElement_Draw.saveToFile();
             }
 
             private static void doNeverSelectStuffForSecondary(int i)
@@ -309,118 +338,190 @@ namespace GameMod {
                 {
                     SFXCueManager.PlayCue2D(SFXCue.hud_weapon_cycle_close, 0.8f, 0f, 0f, false);
                 }
-                DrawMpAutoselectOrderingScreen.saveToFile();
+                MPAutoSelectUI_UIElement_Draw.saveToFile();
             }
 
             private static void doSelectedStuffForPrimary(int i)
             {
                 if (selected < 1)
                 {
-                    DrawMpAutoselectOrderingScreen.isPrimarySelected[i] = true;
+                    MPAutoSelectUI_UIElement_Draw.isPrimarySelected[i] = true;
                     GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                 }
                 else
                 {
-                    if (DrawMpAutoselectOrderingScreen.isPrimarySelected[i])
+                    if (MPAutoSelectUI_UIElement_Draw.isPrimarySelected[i])
                     {
-                        DrawMpAutoselectOrderingScreen.isPrimarySelected[i] = false;
+                        MPAutoSelectUI_UIElement_Draw.isPrimarySelected[i] = false;
                         GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                     }
                     else
                     {
-                        DrawMpAutoselectOrderingScreen.isPrimarySelected[i] = true;
-                        DrawMpAutoselectOrderingScreen.SwapSelectedPrimary();
+                        MPAutoSelectUI_UIElement_Draw.isPrimarySelected[i] = true;
+                        MPAutoSelectUI_UIElement_Draw.SwapSelectedPrimary();
                         SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                     }
                 }
             }
-
 
             private static void doSelectedStuffForSecondary(int i)
             {
                 if (selected2 < 1)
                 {
-                    DrawMpAutoselectOrderingScreen.isSecondarySelected[i] = true;
+                    MPAutoSelectUI_UIElement_Draw.isSecondarySelected[i] = true;
                     GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                 }
                 else
                 {
-                    if (DrawMpAutoselectOrderingScreen.isSecondarySelected[i])
+                    if (MPAutoSelectUI_UIElement_Draw.isSecondarySelected[i])
                     {
-                        DrawMpAutoselectOrderingScreen.isSecondarySelected[i] = false;
+                        MPAutoSelectUI_UIElement_Draw.isSecondarySelected[i] = false;
                         GameManager.m_audio.PlayCue2D(364, 0.4f, 0.07f, 0f, false);
                     }
                     else
                     {
-                        DrawMpAutoselectOrderingScreen.isSecondarySelected[i] = true;
-                        DrawMpAutoselectOrderingScreen.SwapSelectedSecondary();
+                        MPAutoSelectUI_UIElement_Draw.isSecondarySelected[i] = true;
+                        MPAutoSelectUI_UIElement_Draw.SwapSelectedSecondary();
                         SFXCueManager.PlayCue2D(SFXCue.guidebot_objective_found, 0.8f, 0f, 0f, false);
                     }
                 }
             }
+
         }
 
-        // Adds the Auto order entry in the customize menu
-        [HarmonyPatch(typeof(UIElement), "DrawMpTabs")]
-        internal class AddFourthTab
+        [HarmonyPatch(typeof(UIElement), "Draw")]
+        public class MPAutoSelectUI_UIElement_Draw
         {
-            public static bool Prefix(Vector2 pos, int tab_selected, UIElement __instance)
+            static void Postfix(UIElement __instance)
             {
-                float w = 378f; // 511
-                __instance.DrawWideBox(pos, w, 22f, UIManager.m_col_ub2, __instance.m_alpha, 7);
-                string[] array = new string[]
+                if (__instance.m_type == Menus.uiAutoSelect)
                 {
-                __instance.GetMpTabName(0),
-                __instance.GetMpTabName(1),
-                __instance.GetMpTabName(2),
-                "AUTOSELECT"
-                };
-
-                for (int i = 0; i < array.Length; i++)
-                {
-                    pos.x = (((float)i - 1f) * 198f) - 99f;//265 -132
-                    __instance.TestMouseInRect(pos, 84f, 16f, 200 + i, false); // original value = 112
-                    if (UIManager.m_menu_selection == 200 + i)
+                    if (isInitialised == false)
                     {
-                        __instance.DrawWideBox(pos, 84f, 19f, UIManager.m_col_ui4, __instance.m_alpha, 7);
+                        Initialise();
+                        isInitialised = true;
                     }
-                    if (i == tab_selected)
-                    {
-                        __instance.DrawWideBox(pos, 84f, 16f, UIManager.m_col_ui4, __instance.m_alpha, 12);
-                        __instance.DrawStringSmall(array[i], pos, 0.6f, StringOffset.CENTER, UIManager.m_col_ub3, 1f, -1f);
-                    }
-                    else
-                    {
-                        __instance.DrawWideBox(pos, 84f, 16f, UIManager.m_col_ui0, __instance.m_alpha, 8);
-                        __instance.DrawStringSmall(array[i], pos, 0.6f, StringOffset.CENTER, UIManager.m_col_ui1, 1f, -1f);
-                    }
-                }
-                return false;
+                    DrawAutoSelectWindow(__instance);
+                }   
             }
-        }
 
-        [HarmonyPatch(typeof(UIElement), "DrawMpCustomize")]
-        internal class DrawMpAutoselectOrderingScreen
-        {
             static string[] PrimaryPriorityArray = new string[8];
             static string[] SecondaryPriorityArray = new string[8];
 
-            static void Postfix(UIElement __instance)
+            static void DrawAutoSelectWindow(UIElement uie)
             {
-                //Initialise();
-                if (isInitialised == false)
+                UIManager.X_SCALE = 0.2f;
+                UIManager.ui_bg_dark = true;
+                uie.DrawMenuBG();
+
+                Vector2 position = uie.m_position;
+                position.y = UIManager.UI_TOP + 64f;
+                uie.DrawHeaderMedium(Vector2.up * (UIManager.UI_TOP + 40f), Loc.LS("AUTOSELECT"), 265f);
+                position.y += 100f;
+                uie.DrawMenuSeparator(position);
+                position.y -= 40f;
+
+
+
+
+                position.y += 82;
+                Vector2 position2 = position;
+                position.x -= 160f;
+                position2.x += 160f;
+
+                UIColorPrimaries = MPAutoSelection.primarySwapFlag ? UIManager.m_col_ui4 : UIManager.m_col_ui0;
+                UIColorSecondaries = MPAutoSelection.secondarySwapFlag ? UIManager.m_col_ui4 : UIManager.m_col_ub0;
+
+                Vector2 left = position;
+                Vector2 right = position;
+                left.x += 81;
+                right.x += 234;
+
+                //Draw the neverselect Buttons
+                for (int i = 0; i < 8; i++)
                 {
-                    Initialise();
-                    isInitialised = true; //should be set to false when leaving the MpCustomize Menu
+                    int primaryindex = getWeaponIconIndex(MPAutoSelection.PrimaryPriorityArray[i]);
+                    int secondaryindex = getWeaponIconIndex(MPAutoSelection.SecondaryPriorityArray[i]);
+                    UIManager.DrawSpriteUI(left, 0.2f, 0.2f, UIColorPrimaries, uie.m_alpha, 26 + primaryindex);
+                    UIManager.DrawSpriteUI(right, 0.2f, 0.2f, UIColorSecondaries, uie.m_alpha, 104 + secondaryindex);
+
+                    left.y += 50f;
+                    right.y += 50f;
+                    if (MPAutoSelectUI_UIElement_Draw.isPrimarySelected[i])
+                    {
+                        uie.DrawWideBox(position, 100f, 28f, Color.blue, 0.2f, 7);
+                        UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.blue, 12);
+                    }
+                    else if (MPAutoSelection.PrimaryNeverSelect[i])
+                    {
+                        uie.DrawWideBox(position, 100f, 28f, Color.red, 0.2f, 7);
+                        UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.red, 12);
+                    }
+                    position.x -= 150f;
+                    uie.SelectAndDrawItem(!MPAutoSelection.PrimaryNeverSelect[i] ? "+" : "-", position, 2000 + i, false, 0.022f, 1f);
+                    position.x += 150f;
+                    uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);
+                    position.y += 50f;
+
+
+                    if (MPAutoSelectUI_UIElement_Draw.isSecondarySelected[i])
+                    {
+                        uie.DrawWideBox(position2, 100f, 28f, Color.blue, 0.2f, 7);
+                        UIManager.DrawQuadBarHorizontal(position2, 100f, 18f, 30, Color.blue, 12);
+                    }
+                    else if (MPAutoSelection.SecondaryNeverSelect[i])
+                    {
+                        uie.DrawWideBox(position2, 100f, 28f, Color.red, 0.2f, 7);
+                        UIManager.DrawQuadBarHorizontal(position2, 100f, 18f, 30, Color.red, 12);
+                    }
+                    position2.x += 150f;
+                    uie.SelectAndDrawItem((!MPAutoSelection.SecondaryNeverSelect[i] ? "+" : "-"), position2, 2010 + i, false, 0.022f, 1f);
+                    position2.x -= 150f;
+                    uie.SelectAndDrawHalfItem(Secondary[i], position2, 1728 + i, false);
+                    position2.y += 50f;
                 }
 
-                int menu_micro_state = MenuManager.m_menu_micro_state;
-                if (menu_micro_state == 3)
-                {
-                    // Draw the Autoselect Ordering menu
-                    DrawPriorityList(__instance);
-                }
+
+
+                position = left;
+                position.x = 540f;
+                position.y -= 400f;
+                uie.SelectAndDrawItem("Status: " + ((MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag) ? "ACTIVE" : "INACTIVE"), position, 2100, false, 0.3f, 0.45f);
+                position.y += 50f;
+                position.x += 5f;
+                uie.SelectAndDrawItem("Weapon Logic: " + (MPAutoSelection.primarySwapFlag ? "ON" : "OFF"), position, 2103, false, 0.27f, 0.4f);
+                position.y += 50f;
+                uie.SelectAndDrawItem("Missile Logic: " + (MPAutoSelection.secondarySwapFlag ? "ON" : "OFF"), position, 2102, false, 0.27f, 0.4f);
+
+
+                position.x -= 5f;
+                position.y += 147;
+                uie.SelectAndDrawItem("DONT SWAP WHILE FIRING: " + (!MPAutoSelection.swapWhileFiring ? "ON" : "OFF"), position, 2106, false, 0.3f, 0.40f);
+                position.y += 50f;
+                uie.SelectAndDrawItem("RETRY SWAP AFTER FIRING: " + (!MPAutoSelection.dontAutoselectAfterFiring ? "ON" : "OFF"), position, 2105, false, 0.3f, 0.40f);
+                position.y += 50f;
+                uie.SelectAndDrawItem("ALERT: " + (MPAutoSelection.zorc ? "ON" : "OFF"), position, 2104, false, 0.3f, 0.45f);
+
+
+
+                // Button description 
+                position2.x -= 160f;
+                position2.y -= 8f;
+                
+                position2.y -= 8f;
+                string k = selectionToDescription(UIManager.m_menu_selection);
+                MPAutoSelection.last_valid_description = k;
+                position.x = 0f;
+                uie.DrawLabelSmall(position + Vector2.up * 40f, k, 500f); //position2
+                position.y += 12f;
+                uie.DrawMenuSeparator(position + Vector2.up * 40f);
+
+
+                position.x = 0f;
+                position.y = UIManager.UI_BOTTOM - 30f;
+                uie.SelectAndDrawItem(Loc.LS("BACK"), position, 100, fade: false);
             }
+
 
             public static void Initialise()
             {
@@ -442,8 +543,6 @@ namespace GameMod {
                 Secondary[6] = MPAutoSelection.SecondaryPriorityArray[6];
                 Secondary[7] = MPAutoSelection.SecondaryPriorityArray[7];
             }
-
-
 
             public static int returnPrimarySelected()
             {
@@ -576,7 +675,7 @@ namespace GameMod {
 
             public static string selectionToDescription(int n)
             {
-                if (n == 2100) return "TOGGLES WETHER THE WHOLE FMOD SHOULD BE ACTIVE";
+                if (n == 2100) return "TOGGLES WETHER THE WHOLE MOD SHOULD BE ACTIVE";
                 if (n == 2101) return "REPLACES THE `PREV/NEXT WEAPON` FUNCTION WITH `SWAP TO NEXT HIGHER/LOWER PRIORITIZED WEAPONS`";
                 if (n <= 2017 && n >= 2000) return "TOGGLES WETHER THIS WEAPON SHOULD NEVER BE SELECTED";
                 if (n <= 1735 && n >= 1720) return "CHANGE THE ORDER BY CLICKING AT THE TWO WEAPONS YOU WANT TO SWAP";
@@ -608,103 +707,6 @@ namespace GameMod {
                 }
             }
 
-            private static MethodInfo _UIElement_DrawWrappedText_Method = typeof(UIElement).GetMethod("DrawWrappedText", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-            public static void DrawPriorityList(UIElement uie)
-            {
-                UIManager.X_SCALE = 0.2f;
-                UIManager.ui_bg_dark = true;
-                uie.DrawMenuBG();
-
-                Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
-                position.y += 164f;
-                Vector2 position2 = position;
-                position.x -= 160f;
-                position2.x += 160f;
-
-                UIColorPrimaries = MPAutoSelection.primarySwapFlag ? UIManager.m_col_ui4 : UIManager.m_col_ui0;
-                UIColorSecondaries = MPAutoSelection.secondarySwapFlag ? UIManager.m_col_ui4 : UIManager.m_col_ub0;
-
-                Vector2 left = position;
-                Vector2 right = position;
-                left.x += 75;
-                right.x += 240;
-
-                //Draw the neverselect Buttons
-                for (int i = 0; i < 8; i++)
-                {
-                    int primaryindex = getWeaponIconIndex(MPAutoSelection.PrimaryPriorityArray[i]);
-                    int secondaryindex = getWeaponIconIndex(MPAutoSelection.SecondaryPriorityArray[i]);
-                    UIManager.DrawSpriteUI(left, 0.15f, 0.15f, UIColorPrimaries, uie.m_alpha, 26 + primaryindex);
-                    UIManager.DrawSpriteUI(right, 0.15f, 0.15f, UIColorSecondaries, uie.m_alpha, 104 + secondaryindex);
-
-                    left.y += 50;
-                    right.y += 50;
-                    if (DrawMpAutoselectOrderingScreen.isPrimarySelected[i])
-                    {
-                        uie.DrawWideBox(position, 100f, 28f, Color.blue, 0.2f, 7);
-                        UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.blue, 12);
-                    }
-                    else if (MPAutoSelection.PrimaryNeverSelect[i])
-                    {
-                        uie.DrawWideBox(position, 100f, 28f, Color.red, 0.2f, 7);
-                        UIManager.DrawQuadBarHorizontal(position, 100f, 18f, 30f, Color.red, 12);
-                    }
-                    position.x -= 150f;
-                    uie.SelectAndDrawItem(!MPAutoSelection.PrimaryNeverSelect[i] ? "+" : "-", position, 2000 + i, false, 0.022f, 1f);
-                    position.x += 150f;
-                    uie.SelectAndDrawHalfItem(Primary[i], position, 1720 + i, false);
-                    position.y += 50;
-
-
-                    if (DrawMpAutoselectOrderingScreen.isSecondarySelected[i])
-                    {
-                        uie.DrawWideBox(position2, 100f, 28f, Color.blue, 0.2f, 7);
-                        UIManager.DrawQuadBarHorizontal(position2, 100f, 18f, 30, Color.blue, 12);
-                    }
-                    else if (MPAutoSelection.SecondaryNeverSelect[i])
-                    {
-                        uie.DrawWideBox(position2, 100f, 28f, Color.red, 0.2f, 7);
-                        UIManager.DrawQuadBarHorizontal(position2, 100f, 18f, 30, Color.red, 12);
-                    }
-                    position2.x += 150f;
-                    uie.SelectAndDrawItem((!MPAutoSelection.SecondaryNeverSelect[i] ? "+" : "-"), position2, 2010 + i, false, 0.022f, 1f);
-                    position2.x -= 150f;
-                    uie.SelectAndDrawHalfItem(Secondary[i], position2, 1728 + i, false);
-                    position2.y += 50;
-                }
-
-
-                // other Buttons
-                position = Vector2.up * (UIManager.UI_TOP + 70f);
-                position.y += 164f;
-                position.x += 540f;
-                uie.SelectAndDrawItem("Status: " + ((MPAutoSelection.primarySwapFlag || MPAutoSelection.secondarySwapFlag) ? "ACTIVE" : "INACTIVE"), position, 2100, false, 0.3f, 0.45f);
-                position.y += 52f;
-                position.x += 5f;
-                uie.SelectAndDrawItem("Weapon Logic: " + (MPAutoSelection.primarySwapFlag ? "ON" : "OFF"), position, 2103, false, 0.27f, 0.4f);
-                position.y += 50f;
-                uie.SelectAndDrawItem("Missile Logic: " + (MPAutoSelection.secondarySwapFlag ? "ON" : "OFF"), position, 2102, false, 0.27f, 0.4f);
-
-
-                position.x -= 5f;
-                position.y += 147;
-                uie.SelectAndDrawItem("DONT SWAP WHILE FIRING: " + (!MPAutoSelection.swapWhileFiring ? "ON" : "OFF"), position, 2106, false, 0.3f, 0.40f);
-                position.y += 50;
-                uie.SelectAndDrawItem("RETRY SWAP AFTER FIRING: " + (!MPAutoSelection.dontAutoselectAfterFiring ? "ON" : "OFF"), position, 2105, false, 0.3f, 0.40f);
-                position.y += 50;
-                uie.SelectAndDrawItem("ALERT: " + (MPAutoSelection.zorc ? "ON" : "OFF"), position, 2104, false, 0.3f, 0.45f);
-
-
-
-                // Button description 
-                position2.x -= 160f;
-                position2.y -= 14f;
-                string k = selectionToDescription(UIManager.m_menu_selection);
-                MPAutoSelection.last_valid_description = k;
-                uie.DrawLabelSmall(position2, k, 500f);
-
-                _UIElement_DrawWrappedText_Method.Invoke(uie, new object[] { "To enable autoselect, set the option at \"Options\", \"Control Options\", \"Advanced Options\", \"Primary Auto-Select\" to \"Never\".", new Vector2(UIManager.UI_LEFT + 35f, UIManager.UI_TOP + 234f), 0.4f, 15f, 220f, StringOffset.LEFT, float.MaxValue, 0f, 0f });
-            }
             public static bool isInitialised = false;
 
             public static string[] Primary = {
@@ -733,5 +735,7 @@ namespace GameMod {
             private static Color UIColorPrimaries;
             private static Color UIColorSecondaries;
         }
+
+       
     }
 }

--- a/GameMod/MPSniperPackets.cs
+++ b/GameMod/MPSniperPackets.cs
@@ -515,7 +515,7 @@ namespace GameMod
                             player.UpdateCurrentMissileName();
                         }
                     }
-
+                    
                     if (oldAmt == 0 && MPAutoSelection.secondarySwapFlag)
                     {
                         if (GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && player.isLocalPlayer)
@@ -541,7 +541,7 @@ namespace GameMod
                             }
                         }
                     }
-
+                    
                     break;
             }
 

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -14,9 +14,11 @@ namespace GameMod
         //public static MenuState msServerBrowser = (MenuState)75;
         public static MenuState msLagCompensation = (MenuState)76;
         public static MenuState msAutoSelect = (MenuState)77;
+        public static MenuState msAxisCurveEditor = (MenuState)78;
         //public static UIElementType uiServerBrowser = (UIElementType)89;
         public static UIElementType uiLagCompensation = (UIElementType)90;
         public static UIElementType uiAutoSelect = (UIElementType)91;
+        public static UIElementType uiAxisCurveEditor = (UIElementType)92;
         public static bool mms_ctf_boost { get; set; }
 
         public static string GetMMSCtfCarrierBoost()

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -13,8 +13,10 @@ namespace GameMod
 
         //public static MenuState msServerBrowser = (MenuState)75;
         public static MenuState msLagCompensation = (MenuState)76;
+        public static MenuState msAutoSelect = (MenuState)77;
         //public static UIElementType uiServerBrowser = (UIElementType)89;
         public static UIElementType uiLagCompensation = (UIElementType)90;
+        public static UIElementType uiAutoSelect = (UIElementType)91;
         public static bool mms_ctf_boost { get; set; }
 
         public static string GetMMSCtfCarrierBoost()


### PR DESCRIPTION
This contains a bunch of autoselect changes:
1. Moved the Autoselect menu to 'Options/Control Options/Advanced Options/Configure Autoselect'
2. Autoselect now applies to SP/CM as well
3. Removed the now obsolete 'Primary Autoselect' Option
4. Moved the Autoselect setting to a new pilot dependent file: PILOT.extendedconfig
    Reasoning for adding a new file:
      1. Autoselect has a lot of settings which would clutter .xprefsmod.
      2. .xconfigmod doesnt really allow to add more settings without breaking backwards compatibility
      3. I am building a Joystick Curve Editor which needs to save 6 floats per Axis per Controller which depending
          on wether the OS exposes every device that has ever been connected as active (like my ubuntu)
          or just the actually connected devices can add up to a few hundreds of repeating settings that i really 
          didnt want to add to .xprefsmod.

     Function:
      .extendedconfig works in sections in the way that all data belongs to a section with a marker
      if the section gets recognized it passes the lines to its parsing, saving, setdefault functions etc
      if it doesnt it will save the data to readd them when saving so that it doesnt get lost

EDIT: 
This also adds an Curve Editor Menu under 'Options/Control Options/Joystick Options/Controller Axis Settings/Edit Curve'
that allows to set a different response curve for each Axis. 

![curve_editor](https://user-images.githubusercontent.com/34916038/121065870-85ad1980-c7c9-11eb-8003-870dc9045a66.png)

The 4 yellow points that define the curve get stored in PILOT.extendedconfig
The curve gets applied when Overload.Controls.GetAxis requests the current position of an controller axis from rewired.
Instead of returning the axis position it will now use the axis position as an x coordinate to return the curve height at that position 

The default is a line from 0,0 to 1,1 for an unchanged behaviour