### PR TITLE
Client-side Team Colors

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -47,9 +47,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(OverloadDir)\Overload_Data\Managed\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(OverloadDir)\Overload_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Overload\Overload_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Rewired_Core">
       <HintPath>$(OverloadDir)\Overload_Data\Managed\Rewired_Core.dll</HintPath>

--- a/GameMod/MPServerBrowser.cs
+++ b/GameMod/MPServerBrowser.cs
@@ -1000,16 +1000,7 @@ namespace GameMod {
                     yield return new CodeInstruction(OpCodes.Call, mpServerBrowser_UIElement_DrawMpMatchSetup_DrawMatchNotes_Method);
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                 }
-
-                // Re-Add Friendly Fire above Powerup Settings
-                if (state == 3 && code.opcode == OpCodes.Ldstr && (string)code.operand == "POWERUP SETTINGS")
-                {
-                    state = 4;
-                    yield return new CodeInstruction(OpCodes.Ldloca, 0);
-                    yield return new CodeInstruction(OpCodes.Call, mpServerBrowser_UIElement_DrawMpMatchSetup_DrawFriendlyFire_Method);
-                    yield return new CodeInstruction(OpCodes.Ldarg_0);
-                }
-
+                
                 // Move Advanced Match section up slightly
                 if (code.opcode == OpCodes.Ldc_R4 && (float)code.operand == 155)
                     code.operand = 250f;

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -237,6 +237,9 @@ namespace GameMod {
                 Menus.mms_damageeffect_alpha_mult = ModPrefs.GetInt("MP_PM_DAMAGEEFFECT_ALPHA_MULT", Menus.mms_damageeffect_alpha_mult);
                 Menus.mms_damageeffect_drunk_blur_mult = ModPrefs.GetInt("MP_PM_DAMAGEEFFECT_DRUNK_BLUR_MULT", Menus.mms_damageeffect_drunk_blur_mult);
                 Menus.mms_match_time_limit = ModPrefs.GetInt("MP_PM_MATCH_TIME_LIMIT", Menus.mms_match_time_limit);
+                Menus.mms_team_color_default = ModPrefs.GetBool("MP_PM_TEAM_COLOR_DEFAULT", Menus.mms_team_color_default);
+                Menus.mms_team_color_self = ModPrefs.GetInt("MP_PM_TEAM_COLOR_SELF", Menus.mms_team_color_self);
+                Menus.mms_team_color_enemy = ModPrefs.GetInt("MP_PM_TEAM_COLOR_ENEMY", Menus.mms_team_color_enemy);
             }
             else // for compatability with old olmod, no need to add new settings
             {
@@ -287,6 +290,9 @@ namespace GameMod {
             ModPrefs.SetInt("MP_PM_DAMAGEEFFECT_ALPHA_MULT", Menus.mms_damageeffect_alpha_mult);
             ModPrefs.SetInt("MP_PM_DAMAGEEFFECT_DRUNK_BLUR_MULT", Menus.mms_damageeffect_drunk_blur_mult);
             ModPrefs.SetInt("MP_PM_MATCH_TIME_LIMIT", Menus.mms_match_time_limit);
+            ModPrefs.SetBool("MP_PM_TEAM_COLOR_DEFAULT", Menus.mms_team_color_default);
+            ModPrefs.SetInt("MP_PM_TEAM_COLOR_SELF", Menus.mms_team_color_self);
+            ModPrefs.SetInt("MP_PM_TEAM_COLOR_ENEMY", Menus.mms_team_color_enemy);
             ModPrefs.Flush(filename + "mod");
         }
 

--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -76,7 +76,7 @@ namespace GameMod
         {
             var c = MenuManager.mpc_decal_color;
             var cIdx = colorIdx[TeamNum(team)];
-            if (team < MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
+            if (MPTeams.NetworkMatchTeamCount < (int)MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
             {
                 bool my_team = team == GameManager.m_local_player.m_mp_team;
                 cIdx = my_team ? Menus.mms_team_color_self : Menus.mms_team_color_enemy;
@@ -98,7 +98,7 @@ namespace GameMod
 
         public static int TeamColorIdx(MpTeam team)
         {
-            if (team < MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
+            if (MPTeams.NetworkMatchTeamCount < (int)MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
             {
                 bool my_team = team == GameManager.m_local_player.m_mp_team;
                 return my_team ? Menus.mms_team_color_self : Menus.mms_team_color_enemy;
@@ -118,7 +118,8 @@ namespace GameMod
         {
             float sat = cIdx == 8 ? 0.01f : cIdx == 4 && mod == 5 ? 0.6f : 0.95f - mod * 0.05f;
             float bright = mod == 5 ? 0.95f : 0.5f + mod * 0.1f;
-            return HSBColor.ConvertToColor(colors[cIdx], sat, bright);
+            Color c = HSBColor.ConvertToColor(colors[cIdx], sat, bright);
+            return c;
         }
 
         public static void DrawTeamHeader(UIElement uie, Vector2 pos, MpTeam team, float w = 255f)
@@ -815,7 +816,7 @@ namespace GameMod
     {
         static bool Prefix(MpTeam team, ref Color __result)
         {
-            if (team < MpTeam.NUM_TEAMS)
+            if (MPTeams.NetworkMatchTeamCount < (int)MpTeam.NUM_TEAMS)
             {
                 if (Menus.mms_team_color_default)
                     return true;

--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -127,8 +127,15 @@ namespace GameMod
             Color c = TeamColor(team, 1);
             Color c2 = TeamColor(team, 4);
             c.a = uie.m_alpha;
+            string teamName = NetworkMatch.GetTeamName(team);
+            if (MPTeams.NetworkMatchTeamCount < (int)MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
+            {
+                c = c2 = UIManager.m_col_ui0;
+                teamName = $"{Loc.LS("TEAM")} {(int)team+1}";
+            }
+            
             UIManager.DrawQuadBarHorizontal(pos, 13f, 13f, w * 2f, c, 7);
-            uie.DrawStringSmall(NetworkMatch.GetTeamName(team), pos, 0.6f, StringOffset.CENTER, c2, 1f, -1f);
+            uie.DrawStringSmall(teamName, pos, 0.6f, StringOffset.CENTER, c2, 1f, -1f);
         }
 
         public static void DrawLobby(UIElement uie, Vector2 pos)
@@ -272,7 +279,6 @@ namespace GameMod
         public static void SetPlayerGlow(PlayerShip ship, MpTeam team) {
             if (GameplayManager.IsMultiplayerActive && !GameplayManager.IsDedicatedServer() && NetworkMatch.IsTeamMode(NetworkMatch.GetMode())) {
                 var teamcolor = UIManager.ChooseMpColor(team);
-
                 foreach (var mat in ship.m_materials) {
                     // Main damage color
                     if (mat.shader != null)
@@ -1031,6 +1037,21 @@ namespace GameMod
         static bool Prefix(UIElement __instance, Vector2 pos, MpTeam team, int score, float w, bool my_team)
         {
             MPTeams.DrawTeamScoreSmall(__instance, pos, team, score, w, my_team);
+            return false;
+        }
+    }
+
+    // Rim color is Team0/Team1/Anarchy dependent
+    [HarmonyPatch(typeof(PlayerShip), "UpdateRimColor")]
+    class MPTeams_PlayerShip_UpdateRimColor
+    {
+        static bool Prefix(PlayerShip __instance, bool mp)
+        {
+            Color c = UIManager.ChooseMpColor(__instance.c_player.m_mp_team);
+            __instance.m_mp_rim_color.r = c.r * 0.25f;
+            __instance.m_mp_rim_color.g = c.g * 0.25f;
+            __instance.m_mp_rim_color.b = c.b * 0.25f;
+            __instance.m_update_mp_color = true;
             return false;
         }
     }

--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -1,13 +1,14 @@
-﻿using System;
+﻿using Harmony;
+using Overload;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using Harmony;
-using Overload;
 using UnityEngine;
 
-namespace GameMod {
+namespace GameMod
+{
     static class MPTeams
     {
         public static int NetworkMatchTeamCount;
@@ -74,7 +75,22 @@ namespace GameMod {
         public static string TeamName(MpTeam team)
         {
             var c = MenuManager.mpc_decal_color;
-            MenuManager.mpc_decal_color = colorIdx[TeamNum(team)];
+            var cIdx = colorIdx[TeamNum(team)];
+            if (team < MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
+            {
+                bool my_team = team == GameManager.m_local_player.m_mp_team;
+                cIdx = my_team ? Menus.mms_team_color_self : Menus.mms_team_color_enemy;
+            }
+            MenuManager.mpc_decal_color = cIdx;
+            var ret = MenuManager.GetMpDecalColor();
+            MenuManager.mpc_decal_color = c;
+            return ret;
+        }
+
+        public static string ColorName(int index)
+        {
+            var c = MenuManager.mpc_decal_color;
+            MenuManager.mpc_decal_color = index;
             var ret = MenuManager.GetMpDecalColor();
             MenuManager.mpc_decal_color = c;
             return ret;
@@ -82,18 +98,30 @@ namespace GameMod {
 
         public static int TeamColorIdx(MpTeam team)
         {
-            return colorIdx[TeamNum(team)];
+            if (team < MpTeam.NUM_TEAMS && !Menus.mms_team_color_default)
+            {
+                bool my_team = team == GameManager.m_local_player.m_mp_team;
+                return my_team ? Menus.mms_team_color_self : Menus.mms_team_color_enemy;
+            }
+            else
+            {
+                return colorIdx[TeamNum(team)];
+            }
         }
 
         public static Color TeamColor(MpTeam team, int mod)
         {
-            int cIdx = colorIdx[TeamNum(team)];
+            return TeamColorByIndex(TeamColorIdx(team), mod);
+        }
+
+        public static Color TeamColorByIndex(int cIdx, int mod)
+        {
             float sat = cIdx == 8 ? 0.01f : cIdx == 4 && mod == 5 ? 0.6f : 0.95f - mod * 0.05f;
             float bright = mod == 5 ? 0.95f : 0.5f + mod * 0.1f;
             return HSBColor.ConvertToColor(colors[cIdx], sat, bright);
         }
 
-        static void DrawTeamHeader(UIElement uie, Vector2 pos, MpTeam team, float w = 255f)
+        public static void DrawTeamHeader(UIElement uie, Vector2 pos, MpTeam team, float w = 255f)
         {
             Color c = TeamColor(team, 1);
             Color c2 = TeamColor(team, 4);
@@ -427,8 +455,6 @@ namespace GameMod {
     {
         static bool Prefix(MpTeam team, ref string __result)
         {
-            if (team < MpTeam.NUM_TEAMS)
-                return true;
             __result = MPTeams.TeamName(team) + " TEAM";
             return false;
         }
@@ -790,8 +816,26 @@ namespace GameMod {
         static bool Prefix(MpTeam team, ref Color __result)
         {
             if (team < MpTeam.NUM_TEAMS)
-                return true;
-            __result = MPTeams.TeamColor(team, 2);
+            {
+                if (Menus.mms_team_color_default)
+                    return true;
+
+                bool my_team = team == GameManager.m_local_player.m_mp_team;
+                if (my_team)
+                {
+                    __result = MPTeams.TeamColorByIndex(Menus.mms_team_color_self, 2);
+                }
+                else
+                {
+                    __result = MPTeams.TeamColorByIndex(Menus.mms_team_color_enemy, 0);
+                }
+
+            }
+            else
+            {
+                __result = MPTeams.TeamColor(team, 2);
+            }
+
             return false;
         }
     }
@@ -799,15 +843,6 @@ namespace GameMod {
     [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
     class MPTeamsMenuDraw
     {
-        static void Postfix(UIElement __instance)
-        {
-            if (MenuManager.m_menu_micro_state != 2 || !NetworkMatch.IsTeamMode(MenuManager.mms_mode))
-                return;
-            Vector2 position = Vector2.zero;
-            position.y = -279f + 62f * 6;
-            __instance.SelectAndDrawStringOptionItem("TEAM COUNT", position, 8, MPTeams.MenuManagerTeamCount.ToString(), string.Empty, 1.5f,
-                MenuManager.mms_mode == MatchMode.ANARCHY || !MenuManager.m_mp_lan_match);
-        }
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> cs)
         {
             var vector2_y_Field = AccessTools.Field(typeof(Vector2), "y");
@@ -840,40 +875,6 @@ namespace GameMod {
         }
 
     }
-  
-    [HarmonyPatch(typeof(MenuManager), "MpMatchSetup")]
-    class MPTeamsMenuHandle
-    {
-        static void HandleTeamCount()
-        {
-            if (MenuManager.m_menu_sub_state == MenuSubState.ACTIVE &&
-                MenuManager.m_menu_micro_state == 2 &&
-                UIManager.m_menu_selection == 8)
-            {
-                MPTeams.MenuManagerTeamCount = MPTeams.Min +
-                    (MPTeams.MenuManagerTeamCount - MPTeams.Min + (MPTeams.Max - MPTeams.Min + 1) + UIManager.m_select_dir) %
-                    (MPTeams.Max - MPTeams.Min + 1);
-                MenuManager.PlayCycleSound(1f, (float)UIManager.m_select_dir);
-            }
-        }
-
-        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
-        {
-            var mpTeamsMenuHandle_HandleTeamCount_Method = AccessTools.Method(typeof(MPTeamsMenuHandle), "HandleTeamCount");
-
-            foreach (var code in codes)
-            {
-                if (code.opcode == OpCodes.Call && ((MethodInfo)code.operand).Name == "MaybeReverseOption")
-                {
-                    yield return code;
-                    yield return new CodeInstruction(OpCodes.Call, mpTeamsMenuHandle_HandleTeamCount_Method);
-                    continue;
-                }
-
-                yield return code;
-            }
-        }
-    }
 
     [HarmonyPatch(typeof(PlayerShip), "UpdateShipColors")]
     class MPTeamsShipColors
@@ -882,6 +883,7 @@ namespace GameMod {
         {
             if (team == MpTeam.ANARCHY)
                 return;
+
             glow_color = decal_color = MPTeams.TeamColorIdx(team);
             team = MpTeam.ANARCHY; // prevent original team color assignment
         }
@@ -1001,6 +1003,36 @@ namespace GameMod {
             }
         }
     }
-    
+
+    [HarmonyPatch(typeof(UIElement), "DrawTeamHeader")]
+    class MPTeams_UIElement_DrawTeamHeader
+    {
+        static bool Prefix(UIElement __instance, Vector2 pos, MpTeam team, float w)
+        {
+            MPTeams.DrawTeamHeader(__instance, pos, team, w);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(UIElement), "DrawTeamScore")]
+    class MPTeams_UIElement_DrawTeamScore
+    {
+        static bool Prefix(UIElement __instance, Vector2 pos, MpTeam team, int score, float w, bool my_team)
+        {
+            MPTeams.DrawTeamScore(__instance, pos, team, score, w, my_team);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(UIElement), "DrawTeamScoreSmall")]
+    class MPTeams_UIElement_DrawTeamScoreSmall
+    {
+        static bool Prefix(UIElement __instance, Vector2 pos, MpTeam team, int score, float w, bool my_team)
+        {
+            MPTeams.DrawTeamScoreSmall(__instance, pos, team, score, w, my_team);
+            return false;
+        }
+    }
+
     // still missing: chat colors...
 }


### PR DESCRIPTION
Added options to Multiplayer Options to allow client-side customization of two team match colors
- Default: Standard Blue/Orange behavior
- Custom: Selected colors are relative to My Team/Enemy Team