### PR TITLE
Fix camera stutter in multiplayer matches, especially on high frame and monitor refresh rates.

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -127,6 +127,7 @@
     <Compile Include="MPCreeperSync.cs" />
     <Compile Include="MPCustomModeFile.cs" />
     <Compile Include="MPDamageEffects.cs" />
+    <Compile Include="MPErrorSmoothingFix.cs" />
     <Compile Include="MPFixGhostProjectiles.cs" />
     <Compile Include="MPHUDMessage.cs" />
     <Compile Include="MPLongPwd.cs" />

--- a/GameMod/MPErrorSmoothingFix.cs
+++ b/GameMod/MPErrorSmoothingFix.cs
@@ -1,0 +1,147 @@
+using Harmony;
+using Overload;
+using UnityEngine;
+
+namespace GameMod {
+    public class MPErrorSmoothingFix {
+        private static Vector3    lastPosition = new Vector3();
+        private static Quaternion lastRotation = new Quaternion();
+        private static Vector3    currPosition = new Vector3();
+        private static Quaternion currRotation = new Quaternion();
+        private static bool       doManualInterpolation = false;
+        private static bool       targetTransformOverridden = false;
+        private static Transform  targetTransformNode = null;
+
+        /* These were for debugging only
+        private static int hackIsEnabled = 0;
+
+        private static void dump_transform(int level, Transform t)
+        {
+                UnityEngine.Debug.LogFormat("{0}: {1} Lp ({2} {3} {4}) Lr ({5} {6} {7}) Ls ({8} {9} {10})",
+                                level, t.name, t.localPosition.x, t.localPosition.y, t.localPosition.z,
+                                t.localEulerAngles.x, t.localEulerAngles.y, t.localEulerAngles.z,
+                                t.localScale.x, t.localScale.y, t.localScale.z);
+
+        }
+
+        private static void dump_transform_hierarchy(Transform t)
+        {
+                int level = 0;
+                while (t != null) {
+                        dump_transform(level, t);
+                        t=t.parent;
+                        level++;
+                }
+        }
+
+        private static void hack_smooth_command() {
+                int n = uConsole.GetNumParameters();
+                if (n > 0) {
+                        int value = uConsole.GetInt();
+                        hackIsEnabled = value;
+                } else {
+                        hackIsEnabled = (hackIsEnabled >0)?0:1;
+                }
+                UnityEngine.Debug.LogFormat("hack_smooth is now {0}", hackIsEnabled);
+        }
+
+        [HarmonyPatch(typeof(GameManager), "Awake")]
+        class MPErrorSmoothingFix_Controller {
+            static void Postfix() {
+                uConsole.RegisterCommand("hack_smooth", hack_smooth_command);
+            }
+        }
+        */
+
+        // start the manual interpolation phase
+        // this disables Unity's automatic interpolation for the rigid body of the player ship
+        private static void enableManualInterpolation()
+        {
+            doManualInterpolation = true;
+            targetTransformNode = GameManager.m_local_player.c_player_ship.transform;
+            if (targetTransformNode) {
+                GameManager.m_local_player.c_player_ship.c_rigidbody.interpolation = RigidbodyInterpolation.None;
+                currPosition = targetTransformNode.position;
+                currRotation = targetTransformNode.rotation;
+            }
+        }
+
+        // stop the manual interpolation phase
+        // restore Unity's automatic interpolation for the rigid body of the player ship
+        private static void disableManualInterpolation()
+        {
+            doManualInterpolation = false;
+            targetTransformNode = null;
+            targetTransformOverridden = false;
+            GameManager.m_local_player.c_player_ship.c_rigidbody.interpolation = RigidbodyInterpolation.Interpolate;
+        }
+
+        // override the transformation of the target node
+        // use smooth interpolation based on Time.time relative to Time.fixedTime
+        // this should be done PER FRAME
+        private static void doTransformOverride()
+        {
+            // interpolate the position
+            float fract = (Time.time - Time.fixedTime) / Time.fixedDeltaTime;
+            targetTransformNode.position = Vector3.LerpUnclamped(lastPosition, currPosition, fract);
+            targetTransformNode.rotation = Quaternion.SlerpUnclamped(lastRotation, currRotation, fract);
+
+            // mark the transformation as overridden
+            targetTransformOverridden = true;
+        }
+
+        // undo the transformation we modified
+        private static void undoTransformOverride()
+        {
+            if (targetTransformOverridden) {
+                if (targetTransformNode != null) {
+                    targetTransformNode.position = currPosition;
+                    targetTransformNode.rotation = currRotation;
+                }
+                targetTransformOverridden = false;
+            }
+        }
+
+        [HarmonyPatch(typeof(GameManager), "FixedUpdate")]
+        class MPErrorSmoothingFix_UpdateCycle {
+            static void Prefix() {
+                // only on the Client, in Multiplayer, in an active game, not during death roll:
+                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying) {
+                    // undo potential override also before FixedUpdate
+                    undoTransformOverride();
+                }
+            }
+
+            static void Postfix() {
+                // only on the Client, in Multiplayer, in an active game, not during death roll:
+                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying) {
+                    if (!doManualInterpolation) {
+                        enableManualInterpolation();
+                    }
+                    lastPosition = currPosition;
+                    lastRotation = currRotation;
+                    currPosition = targetTransformNode.position;
+                    currRotation = targetTransformNode.rotation;
+                } else if (doManualInterpolation) {
+                    disableManualInterpolation();
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(GameManager), "Update")]
+        class MPErrorSmoothingFix_FixedUpdateCycle {
+            static void Prefix() {
+                if (doManualInterpolation && (targetTransformNode != null)) {
+                    doTransformOverride();
+                }
+            }
+        }
+    
+        [HarmonyPatch(typeof(NetworkMatch), "InitBeforeEachMatch")]
+        class MPErrorSmoothingFix_InitBeforeEachMatch {
+            private static void Prefix() {
+                disableManualInterpolation();
+            }
+        }
+    }
+}


### PR DESCRIPTION
In Overload, the inputs for controlling the ship are used to calculate a _force_ and a _torque_ which is applied to the rigid body of the player ship at each `FixedUpdate` step. The actual movement is carried out by the physics simulation. The in-game camera position is derived from this rigid body (there are some additional transforms to offset the camera position, and to add camera sway and shaking etc., but this is not relevant here).

Since the fixed update and physics tick rate is 60Hz in multiplayer, the rigid body is actually moved in steps of 16.67ms time. However, rendering can happen at a much higher frequency. To get a smooth camera movement `GameManager.m_local_player.c_player_ship.c_rigidbody.interpolation` is set to `Interpolate` (see also https://docs.unity3d.com/ScriptReference/Rigidbody-interpolation.html). This has the following effect (data was captured at about 300 fps  via an `WaitForEndOFrame` script):

[UPDATE: sorry, the labels in all these graphs are swapped, green is `c_rigidbody.position.x` and violet is `v_rigidbody.transform.position.x`]

![interpolation](https://user-images.githubusercontent.com/1835702/125195882-01cacf00-e258-11eb-8c3d-9eb9a89e4e51.png)

The `c_rigidbody.positon` /`.rotation` fields reflect the data from the physics step alone and move in a 60Hz pattern (greenish line), while `c_rigidbody.transform` is smoothly interpolated, but delayed by one physics tick (violet line).

However, DiM Insaner was reporting heavy stutterring issues on a very high spec system, using a 120Hz monitor. Framerate was constantly 120Hz though (and he also uses G-Sync). After further analyzing the data on his machine, I discovered an interesting pattern (I later confrimed this pattern on lots of other machines, including my own, I just never noticed because I play at 60Hz/60fps): Sometime, this interpolation simply stops, `c_rigidbody.transform` shows the same 60Hz jerky pattern over all of the frames, for prolonged intervals during a multiplayer game. The `interpolation` property itself was never changed during these times, though.

After further investigation (and this wasn't easy to find), I was able to identify the problem. Whenever the error smoothing is active, the interpolation breaks down: Here is a plot with both the same graphs from above, and the new blue graph shwoing `m_error_pos.magnitude` (using a separate scale for that on the right):
![interpolation_break_begin](https://user-images.githubusercontent.com/1835702/125196134-edd39d00-e258-11eb-9302-60833b96029d.png)

And it goes back to normal interpolaton as soon as the error smoothing ends:
![interpolation_break_end](https://user-images.githubusercontent.com/1835702/125196168-0f348900-e259-11eb-8537-836cd12f6161.png)

One might argue that error smoothing should converge to zero very fast, but actually, it can stay on very small values (well below being noticeable at all) for very long times. (This might be an issue worth investigating on its own).

What I found is that the interpolation stuff only works between data generated via `Phyiscs.Simulate` calls. In the error smoothing case, the position is modified _after_ the final simulation step for this cycle. Overwriting the transform seems to break interpolation until the next `Simulate` happens, all frames rendered until the next `FixedUpdate` cycle will have the same camera position, and in the next `FixedUpdate` the error smoothing will most likely hit again...

I can see 3 strategies to fix this issue:
1. If we must not modify the transformation after the physics simulation, somehow try to move the error smoothing before the last simulation step. However, the error is defined by the current position of the ship, and the last confirmed position we got from the sever plus the position derived by doing a re-simulation of all inputs of all `FixedUpdate` steps which happened since. But if we want to apply the error one tick before, we need to rewind the ship one frame to get the the same tick in both sides of the difference, and we need to simulate one step less. This also means that the actual error values will change, so we modify the actual path the ship is flying.
2. Just disable `c_rigidbody.interpolation` and do the interpolation manually in some `LateUpdate` function. However, it is not clear which values we need to modify here so that we do not break the further physics simulation of the rigid body in the next cycle. 
3. Leave the logic in place as it is, just _add_ another `Physics.Simulate()` after the error smoothing was applied. But do it in such a way that it is client only, for the local player ship only, and only affects rendering the frames until we reach the next `FixedUpdate`, and undo it there.

This patch uses strategy 3. It might sound like the most absurd approach, but it is actually clean and easy to implement. It just needs a `Postfix` to `GameManager.FixedUpdate`, so it executes only after all the other fixed update stuff is done in an un-modified way, and a `Prefix` to the same function to undo it for the next cycle. In-between, only the `Update` and Rendering stuff is called, and only that ever sees the modified ship and camera position.

And the modification itself actually _removes_ the 16.67ms _delay_ added by the interpolation. Technically, by now interpolating to one frame into the future, we are doing some extrapolation here, but the potential extrapolation overshoot is far too low to be ever noticable within the speed and turn limits of overload. It is actually a bit jerky when you run into heavy collisions, but even then, it is _less_ jerky than the 60Hz pattern you get without, and it will be over-shadowed by the relatively "big" error smoothing values which appear during such collisions anyway. So what you get here is a more direct feeling, without changing the way your input feels and behaves. It is similar to using a display with one frame less latency. And it is more close to the truth because the very next frame rendered right after the `FixedUpdate` will now use the data just calculated from the main `Physics.Simulate` step in there (**not** the additional one we added in - it will reach _that_ data ever only 16.67ms later, when the next `FixedUpdate` will already have kicked in).
