### PR TITLE
disable audio playback on the server

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PresetData.cs" />
     <Compile Include="RearView.cs" />
+    <Compile Include="ServerCleanup.cs" />
     <Compile Include="ServerPing.cs" />
     <Compile Include="ServerPort.cs" />
     <Compile Include="ServerStatLog.cs" />

--- a/GameMod/ServerCleanup.cs
+++ b/GameMod/ServerCleanup.cs
@@ -1,0 +1,69 @@
+using Harmony;
+using Overload;
+using System.Collections.Generic;
+using UnityEngine;
+
+/* NOTE: This class is meant as the central place for "cleaning up" server
+ *       behavior, mainly by disabling stuff which is only neccessary on
+ *       the client.
+ *
+ *       Currently, it only disables audio playback on the server, but
+ *       I plan to add further patches later.
+ */
+namespace GameMod {
+    [HarmonyPatch(typeof(GameManager), "Awake")]
+    class ServerCleanup_GamaManager_Awake {
+        static void Postifx() {
+            if (GameplayManager.IsDedicatedServer()) {
+                AudioListener.pause = true;
+                Debug.Log("Dediacted Server: paused AudioListener");
+            }
+        }
+    }
+
+    /* enable this to hear the server's audio... 
+    [HarmonyPatch(typeof(GameManager), "Update")]
+    class ServerCleanup_GamaManager_OverrideAudioVolume {
+        static void Postfix() {
+            if (GameplayManager.IsDedicatedServer()) {
+                AudioListener.volume=1.0f;
+            }
+        }
+    }
+    */
+
+    [HarmonyPatch(typeof(UnityAudio), "FindNextOpenAudioSlot")]
+    class ServerCleanup_NoOpenAudioSlot {
+        static bool Prefix(ref int __result) {
+            // tell the server we are sorry, but we don't have any audio channels left...
+            if (GameplayManager.IsDedicatedServer()) {
+                __result = -1;
+                //Debug.Log("XXXXX audio playback suppressed on server");
+                return false;
+            }
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(UnityAudio), "PlayMusic")]
+    class ServerCleanup_NoPlayMusic {
+        static bool Prefix() {
+            // suppress PlayMusic requests on the server...
+            if (GameplayManager.IsDedicatedServer()) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(UnityAudio), "UpdateAudio")]
+    class ServerCleanup_NoUpdateAudio {
+        static bool Prefix() {
+            // don't do UpdateAudio on the Server
+            if (GameplayManager.IsDedicatedServer()) {
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Currently, the dedicated server plays all music and sound effects, just
the volume is forced to 0 (in this patch, there is a commented-out code
bit which overrides this volume, so you can hear all the audio it is
playing).

Disabling the music and sound playback on the server should reduce the
server CPU load a bit.

Note: Unity has an `AudioManager` which has a "Disable Audio" property.
Ideally, we could find a way to access this, as it also should prevent
the server from trying to grab an audio device in the first place.
However, there is no direct way from Unity C# scripts to access this
functionality. There is a suggestion on the net to do something like that:
https://gist.github.com/benblo/d8b31eab90195208cc38

	var audioManager = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/AudioManager.asset")[0];
	var serializedManager = new SerializedObject(audioManager);
	var prop = serializedManager.FindProperty("m_DisableAudio");
	prop.boolValue = true;
	serializedManager.ApplyModifiedProperties();

However, we don't have `AssetDatabase` in our Unity Classes, and I have found
no other way to get access to that asset.