### PR TITLE
Race Mode: Invuln fix (Issue #115)

### DIFF
--- a/GameMod/MatchModeRace.cs
+++ b/GameMod/MatchModeRace.cs
@@ -140,6 +140,7 @@ namespace GameMod {
                         flag = player.AddMissileAmmo(Race.GetAmmoAmount(MissileType.HUNTER, super), MissileType.HUNTER, false, super);
                         break;
                     case SuperType.INVULNERABILITY:
+                        player.m_spawn_invul_active = false;
                         flag = player.StartInvul(30, false);
                         break;
                     case SuperType.MISSILE_POD:


### PR DESCRIPTION
This one was a fun one - StartInvul call without explicitly setting Player.m_spawn_invul_active field to false essentially made invuln granted by L2 Upgrade Points behave like spawn invuln, which we know disappears rapidly based on your ship's velocity