### PR TITLE
MP Scoreboards - UI Fixes

### DIFF
--- a/GameMod/MPScoreboards.cs
+++ b/GameMod/MPScoreboards.cs
@@ -18,7 +18,7 @@ namespace GameMod
             public static void DrawMpScoreboardRaw(UIElement uie, ref Vector2 pos)
             {
                 float col1 = -330f; // Player
-                float col2 = !NetworkMatch.m_head_to_head ? 100f : 190f; // Score/Kills
+                float col2 = 100f; // Score/Kills
                 float col3 = 190f; // Assists
                 float col4 = (!NetworkMatch.m_head_to_head) ? 280f : 220f; // Deaths
                 float col5 = 350f; // Ping

--- a/GameMod/MPScoreboards.cs
+++ b/GameMod/MPScoreboards.cs
@@ -347,7 +347,6 @@ namespace GameMod
                         : (players[a].m_assists != players[b].m_assists ? players[b].m_assists.CompareTo(players[a].m_assists) : players[a].m_deaths.CompareTo(players[b].m_deaths))
                 );
                 Color color = MPTeams.TeamColor(team, team == GameManager.m_local_player.m_mp_team ? 2 : 0);
-                Color color2 = (team != MpTeam.TEAM0) ? UIManager.m_col_mpb4 : UIManager.m_col_mpa4;
                 for (int j = 0; j < list.Count; j++)
                 {
                     Player player = NetworkManager.m_PlayersForScoreboard[list[j]];
@@ -359,32 +358,26 @@ namespace GameMod
                         {
                             UIManager.DrawQuadUI(pos, 400f, 13f, UIManager.m_col_ub0, m_alpha * num * 0.1f, 13);
                         }
-                        Color c;
                         if (player.isLocalPlayer)
                         {
                             UIManager.DrawQuadUI(pos, 410f, 12f, color, m_alpha * num * 0.15f, 20);
-                            c = color2;
-                            UIManager.DrawQuadUI(pos - Vector2.up * 12f, 400f, 1.2f, c, m_alpha * num * 0.5f, 4);
-                            UIManager.DrawQuadUI(pos + Vector2.up * 12f, 400f, 1.2f, c, m_alpha * num * 0.5f, 4);
-                        }
-                        else
-                        {
-                            c = color;
+                            UIManager.DrawQuadUI(pos - Vector2.up * 12f, 400f, 1.2f, color, m_alpha * num * 0.5f, 4);
+                            UIManager.DrawQuadUI(pos + Vector2.up * 12f, 400f, 1.2f, color, m_alpha * num * 0.5f, 4);
                         }
 
-                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 35f), 0.11f, 0.11f, c, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod1, true));
-                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 15f), 0.11f, 0.11f, c, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod2, false));
-                        uie.DrawPlayerNameBasic(pos + Vector2.right * col1, player.m_mp_name, c, player.m_mp_rank_true, 0.6f, num, player.m_mp_platform, col2 - col1 - 10f);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col2, ctfStats.Captures, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col3, ctfStats.Pickups, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col4, ctfStats.CarrierKills, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col5, ctfStats.Returns, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col6, player.m_kills, 0.65f, StringOffset.CENTER, c, m_alpha * num);
+                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 35f), 0.11f, 0.11f, color, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod1, true));
+                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 15f), 0.11f, 0.11f, color, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod2, false));
+                        uie.DrawPlayerNameBasic(pos + Vector2.right * col1, player.m_mp_name, color, player.m_mp_rank_true, 0.6f, num, player.m_mp_platform, col2 - col1 - 10f);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col2, ctfStats.Captures, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col3, ctfStats.Pickups, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col4, ctfStats.CarrierKills, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col5, ctfStats.Returns, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col6, player.m_kills, 0.65f, StringOffset.CENTER, color, m_alpha * num);
                         if (MPModPrivateData.AssistScoring)
-                            uie.DrawDigitsVariable(pos + Vector2.right * col7, player.m_assists, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col8, player.m_deaths, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        c = uie.GetPingColor(player.m_avg_ping_ms);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col9, player.m_avg_ping_ms, 0.65f, StringOffset.CENTER, c, m_alpha * num);
+                            uie.DrawDigitsVariable(pos + Vector2.right * col7, player.m_assists, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col8, player.m_deaths, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        color = uie.GetPingColor(player.m_avg_ping_ms);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col9, player.m_avg_ping_ms, 0.65f, StringOffset.CENTER, color, m_alpha * num);
                         pos.y += 25f;
                     }
                 }
@@ -638,7 +631,6 @@ namespace GameMod
                         : (players[a].m_assists != players[b].m_assists ? players[b].m_assists.CompareTo(players[a].m_assists) : players[a].m_deaths.CompareTo(players[b].m_deaths))
                 );
                 Color color = MPTeams.TeamColor(team, team == GameManager.m_local_player.m_mp_team ? 2 : 0);
-                Color color2 = (team != MpTeam.TEAM0) ? UIManager.m_col_mpb4 : UIManager.m_col_mpa4;
                 for (int j = 0; j < list.Count; j++)
                 {
                     Player player = NetworkManager.m_PlayersForScoreboard[list[j]];
@@ -650,32 +642,26 @@ namespace GameMod
                         {
                             UIManager.DrawQuadUI(pos, 400f, 13f, UIManager.m_col_ub0, m_alpha * num * 0.1f, 13);
                         }
-                        Color c;
                         if (player.isLocalPlayer)
                         {
                             UIManager.DrawQuadUI(pos, 410f, 12f, color, m_alpha * num * 0.15f, 20);
-                            c = color2;
-                            UIManager.DrawQuadUI(pos - Vector2.up * 12f, 400f, 1.2f, c, m_alpha * num * 0.5f, 4);
-                            UIManager.DrawQuadUI(pos + Vector2.up * 12f, 400f, 1.2f, c, m_alpha * num * 0.5f, 4);
-                        }
-                        else
-                        {
-                            c = color;
+                            UIManager.DrawQuadUI(pos - Vector2.up * 12f, 400f, 1.2f, color, m_alpha * num * 0.5f, 4);
+                            UIManager.DrawQuadUI(pos + Vector2.up * 12f, 400f, 1.2f, color, m_alpha * num * 0.5f, 4);
                         }
 
-                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 35f), 0.11f, 0.11f, c, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod1, true));
-                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 15f), 0.11f, 0.11f, c, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod2, false));
-                        uie.DrawPlayerNameBasic(pos + Vector2.right * col1, player.m_mp_name, c, player.m_mp_rank_true, 0.6f, num, player.m_mp_platform, col2 - col1 - 10f);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col2, stats.Goals, 0.65f, StringOffset.CENTER, c, m_alpha * num);
+                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 35f), 0.11f, 0.11f, color, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod1, true));
+                        UIManager.DrawSpriteUI(pos + Vector2.right * (col1 - 15f), 0.11f, 0.11f, color, m_alpha * num, Player.GetMpModifierIcon(player.m_mp_mod2, false));
+                        uie.DrawPlayerNameBasic(pos + Vector2.right * col1, player.m_mp_name, color, player.m_mp_rank_true, 0.6f, num, player.m_mp_platform, col2 - col1 - 10f);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col2, stats.Goals, 0.65f, StringOffset.CENTER, color, m_alpha * num);
                         if (MPModPrivateData.AssistScoring)
-                            uie.DrawDigitsVariable(pos + Vector2.right * col3, stats.GoalAssists, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col4, stats.Blunders, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col5, player.m_kills, 0.65f, StringOffset.CENTER, c, m_alpha * num);
+                            uie.DrawDigitsVariable(pos + Vector2.right * col3, stats.GoalAssists, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col4, stats.Blunders, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col5, player.m_kills, 0.65f, StringOffset.CENTER, color, m_alpha * num);
                         if (MPModPrivateData.AssistScoring)
-                            uie.DrawDigitsVariable(pos + Vector2.right * col6, player.m_assists, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col7, player.m_deaths, 0.65f, StringOffset.CENTER, c, m_alpha * num);
-                        c = uie.GetPingColor(player.m_avg_ping_ms);
-                        uie.DrawDigitsVariable(pos + Vector2.right * col8, player.m_avg_ping_ms, 0.65f, StringOffset.CENTER, c, m_alpha * num);
+                            uie.DrawDigitsVariable(pos + Vector2.right * col6, player.m_assists, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col7, player.m_deaths, 0.65f, StringOffset.CENTER, color, m_alpha * num);
+                        color = uie.GetPingColor(player.m_avg_ping_ms);
+                        uie.DrawDigitsVariable(pos + Vector2.right * col8, player.m_avg_ping_ms, 0.65f, StringOffset.CENTER, color, m_alpha * num);
                         pos.y += 25f;
                     }
                 }

--- a/GameMod/MPScoreboards.cs
+++ b/GameMod/MPScoreboards.cs
@@ -350,7 +350,11 @@ namespace GameMod
                 for (int j = 0; j < list.Count; j++)
                 {
                     Player player = NetworkManager.m_PlayersForScoreboard[list[j]];
-                    GameMod.CTF.CTFStats ctfStats = GameMod.CTF.PlayerStats[player.netId];
+
+                    GameMod.CTF.CTFStats ctfStats = new GameMod.CTF.CTFStats();
+                    if (GameMod.CTF.PlayerStats.ContainsKey(player.netId))
+                        ctfStats = GameMod.CTF.PlayerStats[player.netId];
+
                     if (player && !player.m_spectator)
                     {
                         float num = (!player.gameObject.activeInHierarchy) ? 0.3f : 1f;

--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -1141,11 +1141,22 @@ namespace GameMod
             return MPTeams.TeamMessageColor(team);
         }
 
+        static MatchMode IsExtMatchModeAnarchy()
+        {
+            if (NetworkMatch.IsTeamMode(NetworkMatch.GetMode()))
+                return MatchMode.TEAM_ANARCHY;
+
+            return MatchMode.ANARCHY;
+        }
+
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             int state = 0;
             foreach (var code in codes)
             {
+                if (code.opcode == OpCodes.Call && code.operand == AccessTools.Method(typeof(NetworkMatch), "GetMode"))
+                    code.operand = AccessTools.Method(typeof(MPTeams_NetworkMessageManager_AddKillMessage), "IsExtMatchModeAnarchy");
+
                 if (code.opcode == OpCodes.Ldc_I4_3)
                 {
                     state++;


### PR DESCRIPTION
- 1v1 anarchy had misaligned Kills column
- Race mode kill feed behaved like Team Anarchy
- CTF/Monsterball main scoreboard would show local player as orange/blue
- CTF main scoreboard would throw exception if displayed before stats were populated