### PR TITLE
Fix for the inability to reach equal rotation speeds without the time component of max turn ramping

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -110,6 +110,7 @@
     <Compile Include="FrameTime.cs" />
     <Compile Include="GameMod.cs" />
     <Compile Include="JoystickCurveEditor.cs" />
+    <Compile Include="JoystickRotationFix.cs" />
     <Compile Include="LevelError.cs" />
     <Compile Include="MatchModeRace.cs" />
     <Compile Include="MessageTypes.cs" />

--- a/GameMod/JoystickCurveEditor.cs
+++ b/GameMod/JoystickCurveEditor.cs
@@ -547,7 +547,8 @@ namespace GameMod
                         }
                         else if (i == 200)
                         {
-                            result = a.curve_lookup[199] + ((axis_value - 0.995f) / 0.005f * (1f - a.curve_lookup[199]));
+                            result = Mathf.Clamp(a.curve_lookup[199] + ((axis_value - 0.995f) / 0.005f * (a.curve_lookup[199] - a.curve_lookup[198])), 0f, 1f);
+                            //result = a.curve_lookup[199] + ((axis_value - 0.995f) / 0.005f * (1f - a.curve_lookup[199]));
                         }
                         else
                         {

--- a/GameMod/JoystickRotationFix.cs
+++ b/GameMod/JoystickRotationFix.cs
@@ -1,0 +1,322 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using Overload;
+using System.Reflection.Emit;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.Networking;
+using System;
+
+namespace GameMod
+{
+    /// <summary>
+    ///  Goal:    allowing to access the same max speed and the same speed gain that max turn ramping on high provides
+    ///           
+    ///  Author:  luponix 
+    ///  Created: 2021-07-22
+    /// </summary>
+    class JoystickRotationFix
+    {
+
+        public static bool alt_turn_ramp_mode = false;          // defines which behaviour the local client wants to use, gets loaded/saved through MPSetup.cs in .xprefsmod
+        public static Dictionary<uint, int> client_settings = new Dictionary<uint, int>();    // used to store the turn ramp mode setting of the active players on the server side
+        public static bool server_support = true;               // indicates wether the current server supports the changed behaviour, has to be true outside of games to make the ui option accessible
+
+
+
+        [HarmonyPatch(typeof(GameManager), "Start")]
+        internal class CommandsAndInitialisationPatch10
+        {
+            private static void Postfix(GameManager __instance)
+            {
+                uConsole.RegisterCommand("debuginput", "", new uConsole.DebugCommand(CommandsAndInitialisationPatch10.CmdToggleDebugInput));
+            }
+
+            private static void CmdToggleDebugInput()
+            {
+                JoystickCurveEditor.DebugOutput.show = !JoystickCurveEditor.DebugOutput.show;
+            }
+        }
+
+
+
+        // Debug 
+        /*
+        [HarmonyPatch(typeof(Player), "CmdSendFullChat")]
+        internal class JoystickRotationFix_Debug_CmdSendFullChat
+        {
+            static void Postfix(int sender_connection_id, string sender_name, MpTeam sender_team, string msg)
+            {
+                if (msg.ToString().ToUpper().StartsWith("SHOW_JFS"))
+                {
+                    string msg3 = "empty settings";
+                    if (client_settings != null)
+                    {
+                        msg3 = "";
+                        foreach (KeyValuePair<uint, int> entry in client_settings)
+                        {
+                            msg3 += "  Key:" + entry.Key + "  Value:" + entry.Value;
+                        }
+                    }
+                    LobbyChatMessage msg2 = new LobbyChatMessage(sender_connection_id, "SERVER", MpTeam.ANARCHY, msg3, false);
+                    NetworkServer.SendToAll(75, msg2);
+                }
+            }
+        }*/
+
+
+
+        [HarmonyPatch(typeof(PlayerShip), "FixedUpdateProcessControlsInternal")]
+        internal class JoystickRotationFix_FixedUpdateProcessControlsInternal
+        {
+            static PlayerShip _inst;
+
+            static void Prefix(PlayerShip __instance)
+            {
+                _inst = __instance;
+            }
+
+            static IEnumerable<CodeInstruction> Transpiler(ILGenerator ilGen, IEnumerable<CodeInstruction> instructions)
+            {
+                var playerShip_c_player_Field = AccessTools.Field(typeof(PlayerShip), "c_player");
+                var player_cc_turn_vec_Field = AccessTools.Field(typeof(Player), "cc_turn_vec");
+                var joystickRotationFix_MaybeResetVector_Method = AccessTools.Method(typeof(JoystickRotationFix_FixedUpdateProcessControlsInternal), "MaybeResetVector");
+                var joystickRotationFix_MaybeScaleUpRotation_Method = AccessTools.Method(typeof(JoystickRotationFix_FixedUpdateProcessControlsInternal), "MaybeScaleUpRotation");
+
+                var codes = new List<CodeInstruction>(instructions);
+                int state = 0;
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    if (codes[i].opcode == OpCodes.Ldfld && ((FieldInfo)codes[i].operand).Name == "m_ramp_turn")
+                    {
+                        state++;
+                        if (state == 5)
+                        {
+                            var resetNum20 = new[] {
+                                new CodeInstruction(OpCodes.Ldarg_0),
+                                new CodeInstruction(OpCodes.Ldfld, playerShip_c_player_Field),
+                                new CodeInstruction(OpCodes.Ldflda, player_cc_turn_vec_Field),
+                                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(UnityEngine.Vector3), "y")),
+                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeResetVector_Method)
+                            };
+                            var resetNum21 = new[] {
+                                new CodeInstruction(OpCodes.Ldarg_0),
+                                new CodeInstruction(OpCodes.Ldfld, playerShip_c_player_Field),
+                                new CodeInstruction(OpCodes.Ldflda, player_cc_turn_vec_Field),
+                                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(UnityEngine.Vector3), "x")),
+                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeResetVector_Method)
+                            };
+                            var adjustScaling = new[] {
+                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeScaleUpRotation_Method),
+                                new CodeInstruction(OpCodes.Mul, null)
+                            };
+                            codes.InsertRange(i + 22, adjustScaling);
+                            codes.InsertRange(i + 14, resetNum21);
+                            codes.InsertRange(i + 12, adjustScaling);
+                            codes.InsertRange(i + 4, resetNum20);
+                            return codes;
+                        }
+                    }
+                }
+                return codes;
+
+            }
+
+            public static float MaybeResetVector(float original, float changed)
+            {
+                return MaybeChangeRotation() ? changed : original;
+            }
+
+            public static float MaybeScaleUpRotation()
+            {
+                //Vmax = F / (mass * drag)  player.rigidbody.drag = 5.5f
+                return MaybeChangeRotation() ? PlayerShip.m_ramp_max[_inst.c_player.m_player_control_options.opt_joy_ramp] : 1f;
+            }
+
+            public static bool MaybeChangeRotation()
+            {
+                // (Server) if this is the server lookup the current players setting with _inst
+                if (GameplayManager.IsDedicatedServer())
+                {
+                    if (client_settings.ContainsKey(_inst.netId.Value))
+                    {
+                        client_settings.TryGetValue(_inst.netId.Value, out int val);
+                        return val == 1;
+                    }
+                    return false;
+                }
+                // (Client)
+                return alt_turn_ramp_mode && server_support;
+            }
+        }
+
+        public class SetTurnRampModeMessage : MessageBase
+        {
+            public int mode;
+            public uint netId;
+            public override void Serialize(NetworkWriter writer)
+            {
+                writer.Write(mode);
+                writer.Write(netId);
+            }
+            public override void Deserialize(NetworkReader reader)
+            {
+                mode = reader.ReadInt32();
+                netId = reader.ReadUInt32();
+            }
+        }
+
+        // reset the stored client settings after each match and make sure that the menu option on the clients is enabled
+
+
+
+        /// ///////////////////////////////////// SERVER ///////////////////////////////////// ///
+        [HarmonyPatch(typeof(Server), "RegisterHandlers")]
+        class JoystickRotationFix_Server_RegisterHandlers
+        {
+            private static void OnSetJoystickRampMode(NetworkMessage rawMsg)
+            {
+                var msg = rawMsg.ReadMessage<SetTurnRampModeMessage>();
+                if (client_settings.ContainsKey(msg.netId)) client_settings.Remove(msg.netId);
+                client_settings.Add(msg.netId, msg.mode);
+            }
+
+            static void Postfix()
+            {
+                if (GameplayManager.IsDedicatedServer())
+                {
+                    NetworkServer.RegisterHandler(MessageTypes.MsgSetTurnRampMode, OnSetJoystickRampMode);
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(Server), "SendPostgameToAllClients")]
+        class JoystickRotationFix_Server_SendPostgameToAllClients
+        {
+            private static void Postfix()
+            {
+                client_settings.Clear();
+            }
+        }
+
+
+        /// ///////////////////////////////////// CLIENT ///////////////////////////////////// ///
+        [HarmonyPatch(typeof(Client), "OnMatchStart")] //SendPlayerLoadoutToServer
+        class JoystickRotationFix_SendPlayerLoadoutToServer
+        {
+            private static void Postfix()
+            {
+                if (GameplayManager.IsDedicatedServer()) return;
+                if (Client.GetClient() == null)
+                {
+                    Debug.Log("JoystickRamping_SendPlayerLoadoutToServer: no client?");
+                    return;
+                }
+                NetworkIdentity ni = GameManager.m_local_player.GetComponent<NetworkIdentity>();
+                uConsole.Log("----------> just sent " + GameManager.m_local_player.netId.Value + ", " + alt_turn_ramp_mode + "   " + ni.netId.Value + "  <----------");
+                Client.GetClient().Send(MessageTypes.MsgSetTurnRampMode,
+                    new SetTurnRampModeMessage
+                    {
+                        mode = alt_turn_ramp_mode ? 1 : 0,
+                        netId = ni.netId.Value
+                    });
+            }
+        }
+
+        [HarmonyPatch(typeof(NetworkMatch), "ExitMatch")]
+        internal class JoystickRotationFix_NetworkMatch_ExitMatch
+        {
+            static void Postfix()
+            {
+                server_support = true;
+            }
+        }
+
+        [HarmonyPatch(typeof(Client), "Disconnect")]
+        class JoystickRotationFix_Client_Disconnect
+        {
+            private static void Postfix()
+            {
+                server_support = true;
+            }
+        }
+
+        /// ///////////////////////////////////// CLIENT UI ///////////////////////////////////// ///
+        [HarmonyPatch(typeof(UIElement), "DrawControlsMenu")]
+        internal class JoystickRotationFix_DrawControlsMenu
+        {
+            private static void DrawTurnspeedModeOption(UIElement uie, ref Vector2 position)
+            {
+                if (!server_support && !GameplayManager.IsMultiplayerActive && NetworkMatch.GetMatchState() != MatchState.LOBBY)
+                {
+                    server_support = true;
+                    Debug.Log("JoystickRamping.server_support didnt reset properly");
+                }
+                position.y += 62f;
+                uie.SelectAndDrawStringOptionItem(Loc.LS("TURN RAMP MODE"), position, 0, alt_turn_ramp_mode ? "LINEAR" : "DEFAULT", Loc.LS(""), 1.5f, !server_support);
+            }
+
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                var codes = new List<CodeInstruction>(instructions);
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    if (codes[i].opcode == OpCodes.Ldstr && (string)codes[i].operand == "MAX TURN RAMPING")
+                    {
+                        var newCodes = new[] {
+                            new CodeInstruction(OpCodes.Ldarg_0),
+                            new CodeInstruction(OpCodes.Ldloca, 0),
+                            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(JoystickRotationFix_DrawControlsMenu), "DrawTurnspeedModeOption"))
+                        };
+                        codes.InsertRange(i + 9, newCodes);
+                        break;
+                    }
+                }
+                return codes;
+            }
+        }
+
+
+
+        [HarmonyPatch(typeof(MenuManager), "ControlsOptionsUpdate")]
+        internal class JoystickRotationFix_ControlsOptionsUpdate
+        {
+            private static void ProcessTurnRampModeButtonPress()
+            {
+                alt_turn_ramp_mode = !alt_turn_ramp_mode;
+                // also send the updated state to the server if the client is currently in a game
+                if (GameplayManager.IsMultiplayerActive)
+                {
+                    if (Client.GetClient() == null)
+                    {
+                        Debug.Log("JoystickRamping_ControlsOptionsUpdate: no client?");
+                        return;
+                    }
+                    //Debug.Log("Just sent the updated flag to the server: current: " + (alt_turn_ramp_mode ? "LINEAR" : "DEFAULT"));
+                    Client.GetClient().Send(MessageTypes.MsgSetTurnRampMode, new SetTurnRampModeMessage { mode = alt_turn_ramp_mode ? 1 : 0, netId = GameManager.m_local_player.netId.Value });
+                }
+            }
+
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                var codes = new List<CodeInstruction>(instructions);
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    if (codes[i].opcode == OpCodes.Ldsfld && (codes[i].operand as FieldInfo).Name == "opt_primary_autoswitch")
+                    {
+                        // remove the button press handling of the 'PRIMARY AUTOSELECT' option
+                        codes.RemoveRange(i + 1, 6);
+                        // adds logic to handle button presses of the new option
+                        codes.Insert(i + 2, new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(JoystickRotationFix_ControlsOptionsUpdate), "ProcessTurnRampModeButtonPress")));
+                        break;
+                    }
+                }
+                return codes;
+            }
+        }
+
+
+    }
+}
+
+

--- a/GameMod/JoystickRotationFix.cs
+++ b/GameMod/JoystickRotationFix.cs
@@ -18,52 +18,9 @@ namespace GameMod
     class JoystickRotationFix
     {
 
-        public static bool alt_turn_ramp_mode = false;          // defines which behaviour the local client wants to use, gets loaded/saved through MPSetup.cs in .xprefsmod
-        public static Dictionary<uint, int> client_settings = new Dictionary<uint, int>();    // used to store the turn ramp mode setting of the active players on the server side
-        public static bool server_support = true;               // indicates wether the current server supports the changed behaviour, has to be true outside of games to make the ui option accessible
-
-
-
-        [HarmonyPatch(typeof(GameManager), "Start")]
-        internal class CommandsAndInitialisationPatch10
-        {
-            private static void Postfix(GameManager __instance)
-            {
-                uConsole.RegisterCommand("debuginput", "", new uConsole.DebugCommand(CommandsAndInitialisationPatch10.CmdToggleDebugInput));
-            }
-
-            private static void CmdToggleDebugInput()
-            {
-                JoystickCurveEditor.DebugOutput.show = !JoystickCurveEditor.DebugOutput.show;
-            }
-        }
-
-
-
-        // Debug 
-        /*
-        [HarmonyPatch(typeof(Player), "CmdSendFullChat")]
-        internal class JoystickRotationFix_Debug_CmdSendFullChat
-        {
-            static void Postfix(int sender_connection_id, string sender_name, MpTeam sender_team, string msg)
-            {
-                if (msg.ToString().ToUpper().StartsWith("SHOW_JFS"))
-                {
-                    string msg3 = "empty settings";
-                    if (client_settings != null)
-                    {
-                        msg3 = "";
-                        foreach (KeyValuePair<uint, int> entry in client_settings)
-                        {
-                            msg3 += "  Key:" + entry.Key + "  Value:" + entry.Value;
-                        }
-                    }
-                    LobbyChatMessage msg2 = new LobbyChatMessage(sender_connection_id, "SERVER", MpTeam.ANARCHY, msg3, false);
-                    NetworkServer.SendToAll(75, msg2);
-                }
-            }
-        }*/
-
+        public static bool alt_turn_ramp_mode = false;                                      // defines which behaviour the local player uses, gets loaded/saved through MPSetup.cs in .xprefsmod
+        public static Dictionary<uint, int> client_settings = new Dictionary<uint, int>();  // used to store the turn ramp mode setting of the active players on the server
+        public static bool server_support = true;                                           // indicates wether the current server supports the changed behaviour, has to be true outside of games to make the ui option accessible
 
 
         [HarmonyPatch(typeof(PlayerShip), "FixedUpdateProcessControlsInternal")]
@@ -75,12 +32,13 @@ namespace GameMod
             {
                 _inst = __instance;
             }
-
+            // resets num20 to cc_turn_vec.y, num21 to cc_turn_vec.x and multiplies them with the selected PlayerShip.m_ramp_max[] if the linear behaviour is 
+            // selected and supported on the server
             static IEnumerable<CodeInstruction> Transpiler(ILGenerator ilGen, IEnumerable<CodeInstruction> instructions)
             {
                 var playerShip_c_player_Field = AccessTools.Field(typeof(PlayerShip), "c_player");
                 var player_cc_turn_vec_Field = AccessTools.Field(typeof(Player), "cc_turn_vec");
-                var joystickRotationFix_MaybeResetVector_Method = AccessTools.Method(typeof(JoystickRotationFix_FixedUpdateProcessControlsInternal), "MaybeResetVector");
+                var joystickRotationFix_MaybeResetToInput_Method = AccessTools.Method(typeof(JoystickRotationFix_FixedUpdateProcessControlsInternal), "MaybeResetToInput");
                 var joystickRotationFix_MaybeScaleUpRotation_Method = AccessTools.Method(typeof(JoystickRotationFix_FixedUpdateProcessControlsInternal), "MaybeScaleUpRotation");
 
                 var codes = new List<CodeInstruction>(instructions);
@@ -97,14 +55,14 @@ namespace GameMod
                                 new CodeInstruction(OpCodes.Ldfld, playerShip_c_player_Field),
                                 new CodeInstruction(OpCodes.Ldflda, player_cc_turn_vec_Field),
                                 new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(UnityEngine.Vector3), "y")),
-                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeResetVector_Method)
+                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeResetToInput_Method)
                             };
                             var resetNum21 = new[] {
                                 new CodeInstruction(OpCodes.Ldarg_0),
                                 new CodeInstruction(OpCodes.Ldfld, playerShip_c_player_Field),
                                 new CodeInstruction(OpCodes.Ldflda, player_cc_turn_vec_Field),
                                 new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(UnityEngine.Vector3), "x")),
-                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeResetVector_Method)
+                                new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeResetToInput_Method)
                             };
                             var adjustScaling = new[] {
                                 new CodeInstruction(OpCodes.Call, joystickRotationFix_MaybeScaleUpRotation_Method),
@@ -122,14 +80,13 @@ namespace GameMod
 
             }
 
-            public static float MaybeResetVector(float original, float changed)
+            public static float MaybeResetToInput(float original, float changed)
             {
                 return MaybeChangeRotation() ? changed : original;
             }
 
             public static float MaybeScaleUpRotation()
             {
-                //Vmax = F / (mass * drag)  player.rigidbody.drag = 5.5f
                 return MaybeChangeRotation() ? PlayerShip.m_ramp_max[_inst.c_player.m_player_control_options.opt_joy_ramp] : 1f;
             }
 
@@ -166,9 +123,6 @@ namespace GameMod
             }
         }
 
-        // reset the stored client settings after each match and make sure that the menu option on the clients is enabled
-
-
 
         /// ///////////////////////////////////// SERVER ///////////////////////////////////// ///
         [HarmonyPatch(typeof(Server), "RegisterHandlers")]
@@ -201,7 +155,7 @@ namespace GameMod
 
 
         /// ///////////////////////////////////// CLIENT ///////////////////////////////////// ///
-        [HarmonyPatch(typeof(Client), "OnMatchStart")] //SendPlayerLoadoutToServer
+        [HarmonyPatch(typeof(Client), "OnMatchStart")] // m_local_player.netId will return 0 or an old netid if this gets called earlier than OnMatchStart
         class JoystickRotationFix_SendPlayerLoadoutToServer
         {
             private static void Postfix()
@@ -212,13 +166,11 @@ namespace GameMod
                     Debug.Log("JoystickRamping_SendPlayerLoadoutToServer: no client?");
                     return;
                 }
-                NetworkIdentity ni = GameManager.m_local_player.GetComponent<NetworkIdentity>();
-                uConsole.Log("----------> just sent " + GameManager.m_local_player.netId.Value + ", " + alt_turn_ramp_mode + "   " + ni.netId.Value + "  <----------");
                 Client.GetClient().Send(MessageTypes.MsgSetTurnRampMode,
                     new SetTurnRampModeMessage
                     {
                         mode = alt_turn_ramp_mode ? 1 : 0,
-                        netId = ni.netId.Value
+                        netId = GameManager.m_local_player.netId.Value
                     });
             }
         }
@@ -253,7 +205,7 @@ namespace GameMod
                     Debug.Log("JoystickRamping.server_support didnt reset properly");
                 }
                 position.y += 62f;
-                uie.SelectAndDrawStringOptionItem(Loc.LS("TURN RAMP MODE"), position, 0, alt_turn_ramp_mode ? "LINEAR" : "DEFAULT", Loc.LS(""), 1.5f, !server_support);
+                uie.SelectAndDrawStringOptionItem(Loc.LS("MAX TURN RAMP MODE"), position, 0, alt_turn_ramp_mode ? "LINEAR" : "DEFAULT", "LINEAR ADDS THE MAX TURN RAMPING SPEED LINEARLY ALONG THE INPUT [KB/JOYSTICK ONLY]", 1.5f, !server_support);
             }
 
             static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -292,7 +244,6 @@ namespace GameMod
                         Debug.Log("JoystickRamping_ControlsOptionsUpdate: no client?");
                         return;
                     }
-                    //Debug.Log("Just sent the updated flag to the server: current: " + (alt_turn_ramp_mode ? "LINEAR" : "DEFAULT"));
                     Client.GetClient().Send(MessageTypes.MsgSetTurnRampMode, new SetTurnRampModeMessage { mode = alt_turn_ramp_mode ? 1 : 0, netId = GameManager.m_local_player.netId.Value });
                 }
             }

--- a/GameMod/MPModPrivateData.cs
+++ b/GameMod/MPModPrivateData.cs
@@ -1236,6 +1236,12 @@ END_ENTRY
         }
         public static bool AssistScoring { get; set; } = true;
 
+        public static bool JoystickRotationFixSupported
+        {
+            get { return true; }
+            set { JoystickRotationFix.server_support = value; }
+        }
+
         public static JObject Serialize()
         {
             JObject jobject = new JObject();
@@ -1257,6 +1263,7 @@ END_ENTRY
             jobject["customprojdata"] = CustomProjdata;
             jobject["matchtimelimit"] = MatchTimeLimit;
             jobject["assistscoring"] = AssistScoring;
+            jobject["joystickrotationfixsupported"] = JoystickRotationFixSupported;
             return jobject;
         }
 
@@ -1284,6 +1291,7 @@ END_ENTRY
             if (MatchTimeLimit >= 0)
                 NetworkMatch.m_match_time_limit_seconds = MatchTimeLimit;
             AssistScoring = root["assistscoring"].GetBool(true);
+            JoystickRotationFixSupported = root["joystickrotationfixsupported"].GetBool(false);
         }
 
         public static string GetModeString(MatchMode mode)

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -222,6 +222,7 @@ namespace GameMod {
                 ExtMenuManager.mms_ext_lap_limit = ModPrefs.GetInt("MP_PM_LAP_LIMIT", ExtMenuManager.mms_ext_lap_limit);
                 Console.KeyEnabled = ModPrefs.GetBool("O_CONSOLE_KEY", Console.KeyEnabled);
                 Console.CustomUIColor = ModPrefs.GetInt("O_CUSTOM_UI_COLOR", Console.CustomUIColor);
+                JoystickRotationFix.alt_turn_ramp_mode = ModPrefs.GetBool("SCALE_UP_ROTATION", JoystickRotationFix.alt_turn_ramp_mode);
                 Menus.mms_scale_respawn_time = ModPrefs.GetBool("MP_PM_SCALE_RESPAWN_TIME", Menus.mms_scale_respawn_time);
                 if (Core.GameMod.HasInternetMatch())
                     MPInternet.MenuIPAddress = ModPrefs.GetString("MP_PM_IP_ADDRESS", MPInternet.MenuIPAddress);
@@ -276,6 +277,7 @@ namespace GameMod {
             ModPrefs.SetInt("MP_PM_LAP_LIMIT", ExtMenuManager.mms_ext_lap_limit);
             ModPrefs.SetBool("O_CONSOLE_KEY", Console.KeyEnabled);
             ModPrefs.SetInt("O_CUSTOM_UI_COLOR", Console.CustomUIColor);
+            ModPrefs.SetBool("SCALE_UP_ROTATION", JoystickRotationFix.alt_turn_ramp_mode);
             ModPrefs.SetString("MP_PM_IP_ADDRESS", MPInternet.MenuIPAddress);
             ModPrefs.SetBool("MP_PM_SCALE_RESPAWN_TIME", Menus.mms_scale_respawn_time);
             ModPrefs.SetInt("MP_PM_LAG_COMPENSATION", Menus.mms_lag_compensation);

--- a/GameMod/MessageTypes.cs
+++ b/GameMod/MessageTypes.cs
@@ -35,6 +35,8 @@ namespace GameMod
         public const short MsgNewPlayerSnapshotToClient = 140;
         public const short MsgCTFPlayerStats = 141;
         public const short MsgMonsterballPlayerStats = 142;
+
+        public const short MsgSetTurnRampMode = 145;
         // Do not use 400, it is in use by Mod-Projdata.dll.
     }
 }


### PR DESCRIPTION
based on the issues from https://discord.com/channels/453094288742678539/815291248305897493/857663886665056256

This adds a "MAX TURN RAMP MODE" option under Controls/Advanced Options with the options Default and Linear
- Default will behave the same as revivals implementation.
- Linear will remove the curve applied to the input  (the curve is input^1.5 so it covers the same 0-1 range as the input)
  and multiply the result with 1, 1.35, 1.75, 2.5 (playerShip.m_ramp_max) depending on what m_player_control_options.opt_joy_ramp    value the player has chosen. (removing the curve is technically not necessary but it makes for a much better foundation for the curve editor) (If the player joins a server that doesnt support the Linear mode it will fallback to the default mode) (Linear stays in the same limits as Mouse and Default)