### PR TITLE
Fix player ships not moving in the POSTGAME phase.

### DIFF
--- a/GameMod/MPClientExtrapolation.cs
+++ b/GameMod/MPClientExtrapolation.cs
@@ -630,7 +630,7 @@ namespace GameMod {
     class MPClientExtrapolation_ClientUpdate{
         static bool Prefix(){
             // This function is called once per frame from Client.Update()
-            if (Overload.NetworkManager.IsServer() || NetworkMatch.m_match_state != MatchState.PLAYING) {
+            if (Overload.NetworkManager.IsServer() || (NetworkMatch.m_match_state != MatchState.PLAYING && NetworkMatch.m_match_state != MatchState.POSTGAME))  {
                 // no need to move ships around
                 return false;
             }

--- a/GameMod/MPClientExtrapolation.cs
+++ b/GameMod/MPClientExtrapolation.cs
@@ -644,9 +644,6 @@ namespace GameMod {
     [HarmonyPatch(typeof(Client), "FixedUpdate")]
     class MPClientExtrapolation_ClientFixedUpdate{
         static bool Prefix(){
-            if (Overload.NetworkManager.IsServer() || NetworkMatch.m_match_state != MatchState.PLAYING) {
-                return true;
-            }
             // Client.FixedUpdate() did nothing except call UpdateInterpolationBuffer,
             // which we now ignore
             return false;


### PR DESCRIPTION
I introduced this bug when I tried to prevent the "ghost collision sounds"
which resulted from the lag compensation extrapolating the ship positions
into infinity after the gameplay ended. However, the ships should be
allowed to move in the POSTGAME phase, too, not only in PLAYING state.
