### PR TITLE
Small improvements and cleanups for MPErrorSmoothingFix.cs

### DIFF
--- a/GameMod/MPErrorSmoothingFix.cs
+++ b/GameMod/MPErrorSmoothingFix.cs
@@ -112,8 +112,8 @@ namespace GameMod
         {
             static void Prefix()
             {
-                // only on the Client, in Multiplayer, in an active game, not during death roll:
-                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !MPObserver.Enabled)
+                // only on the Client, in Multiplayer, in an active game, not during death or death roll:
+                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead && !MPObserver.Enabled)
                 {
                     // undo potential override also before FixedUpdate
                     undoTransformOverride();
@@ -122,11 +122,11 @@ namespace GameMod
 
             static void Postfix()
             {
-                // only on the Client, in Multiplayer, in an active game, not during death roll:
+                // only on the Client, in Multiplayer, in an active game, not during death or death roll:
                 if (MPObserver.Enabled)
                     return;
 
-                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying)
+                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead)
                 {
                     if (!doManualInterpolation)
                     {

--- a/GameMod/MPErrorSmoothingFix.cs
+++ b/GameMod/MPErrorSmoothingFix.cs
@@ -112,21 +112,14 @@ namespace GameMod
         {
             static void Prefix()
             {
-                // only on the Client, in Multiplayer, in an active game, not during death or death roll:
-                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead && !MPObserver.Enabled)
-                {
-                    // undo potential override also before FixedUpdate
-                    undoTransformOverride();
-                }
+                // undo potential override also before FixedUpdate
+                undoTransformOverride();
             }
 
             static void Postfix()
             {
                 // only on the Client, in Multiplayer, in an active game, not during death or death roll:
-                if (MPObserver.Enabled)
-                    return;
-
-                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead)
+                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead && !MPObserver.Enabled )
                 {
                     if (!doManualInterpolation)
                     {
@@ -134,8 +127,11 @@ namespace GameMod
                     }
                     lastPosition = currPosition;
                     lastRotation = currRotation;
-                    currPosition = targetTransformNode.position;
-                    currRotation = targetTransformNode.rotation;
+                    if (targetTransformNode != null)
+                    {
+                        currPosition = targetTransformNode.position;
+                        currRotation = targetTransformNode.rotation;
+                    }
                 }
                 else if (doManualInterpolation)
                 {
@@ -149,9 +145,6 @@ namespace GameMod
         {
             static void Prefix()
             {
-                if (MPObserver.Enabled)
-                    return;
-
                 if (doManualInterpolation && (targetTransformNode != null))
                 {
                     doTransformOverride();
@@ -164,9 +157,6 @@ namespace GameMod
         {
             private static void Prefix()
             {
-                if (MPObserver.Enabled)
-                    return;
-
                 disableManualInterpolation();
             }
         }


### PR DESCRIPTION
This improves the error smoothing fix in the following ways:
- Also disable manual interpolation when `m_dead` is true (before, it only considered `m_dying`)
- Make sure we always restore the expected transformation state if we did modify it before.

This also adds some cleanups to the general logic, and deals with `MPObersver.Enabled` only at one central place when deciding if manual interpolation should be enabled. 