### PR TITLE
Fix JIP invisible players bug

### DIFF
--- a/GameMod/MPJoinInProgress.cs
+++ b/GameMod/MPJoinInProgress.cs
@@ -37,7 +37,7 @@ namespace GameMod {
             return GameManager.MultiplayerMission.GetLevelFileName(m_match_force_playlist_level_idx);
         }
 
-        public static void SetReady(Player player, bool ready)
+        public static void SetReady(Player player, bool ready, bool serverPreReady = false)
         {
             // Keep track of who has been set ready so we're not wasting CPU cycles making someone visible who is already visible.  Especially needed with the JIP visibility workaround.
             if (ready)
@@ -61,8 +61,8 @@ namespace GameMod {
             player.c_player_ship.gameObject.layer = ready ? 9 : 2;
             player.c_player_ship.enabled = ready;
             player.c_player_ship.gameObject.SetActive(ready);
-            player.enabled = ready;
-            player.gameObject.SetActive(ready);
+            player.enabled = ready || serverPreReady;
+            player.gameObject.SetActive(ready || serverPreReady);
 
             if (ready)
             {
@@ -379,7 +379,7 @@ namespace GameMod {
                         NetworkServer.SendToClient(player.connectionToClient.connectionId, MessageTypes.MsgJIPJustJoined, new JIPJustJoinedMessage { playerId = newPlayer.netId, ready = false });
                     }
                 }
-                MPJoinInProgress.SetReady(newPlayer, false);
+                MPJoinInProgress.SetReady(newPlayer, false, true); // special case: do not disable the player completely, as this would prevent this player to be sent to new clients joining before we finally switch to ready
             }
 
             pregameWait = SendPreGame(connectionId, pregameWait);


### PR DESCRIPTION
This fixes #102.

The issue is that when we do JIP, we completely disable the new player during the 3 seconds prematch countdown, not only on all clients, but on the server, too. If a second client connects during that time, the disabled player will not be sent to the new client at all.

This patch modifies `SetReady()` so that on the server, we still disable the player ship and the collider, but we do not completely disable the `Player` object itself any more.