### PR TITLE
Fix "ship flying through walls" on first spawn.

### DIFF
--- a/GameMod/MPErrorSmoothingFix.cs
+++ b/GameMod/MPErrorSmoothingFix.cs
@@ -118,8 +118,8 @@ namespace GameMod
 
             static void Postfix()
             {
-                // only on the Client, in Multiplayer, in an active game, not during death or death roll:
-                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead && !MPObserver.Enabled )
+                // only on the Client, in Multiplayer, in an active game, not during death or death roll or pregame:
+                if (!Server.IsActive() && GameplayManager.IsMultiplayerActive && NetworkMatch.InGameplay() && !GameManager.m_local_player.c_player_ship.m_dying && !GameManager.m_local_player.c_player_ship.m_dead && !GameManager.m_local_player.m_pregame && !MPObserver.Enabled)
                 {
                     if (!doManualInterpolation)
                     {


### PR DESCRIPTION
Do not turn on manual interpolation while player still is in `m_pregame` state.

This attempts to address issue #155.