### PR TITLE
Lag compensation: add option to limit how far ships might dive into walls.

### DIFF
--- a/GameMod/MPClientExtrapolation.cs
+++ b/GameMod/MPClientExtrapolation.cs
@@ -490,7 +490,39 @@ namespace GameMod {
             if (HandlePlayerRespawn(player,snapshot)) {
                 return;
             }
-            player.c_player_ship.c_transform.localPosition = Vector3.LerpUnclamped(snapshot.m_pos, snapshot.m_pos+snapshot.m_vel, t);
+            Vector3 newPos = Vector3.LerpUnclamped(snapshot.m_pos, snapshot.m_pos+snapshot.m_vel, t);
+            // limit ship dive-in if enabled:
+            if (Menus.mms_lag_compensation_collision_limit > 0) {
+                const float radius = 0.98f; /// the ship's collider is radius 1, we use a bit smaller one
+                Vector3 basePos = snapshot.m_pos;
+                Vector3 deltaPos = newPos - basePos;
+                float dist = deltaPos.magnitude;
+                if (dist > 0.05f) { // only if ship is moved by a significant amount
+                    // NOTE: we only test against LAVA and LEVEL, not other players, because that
+                    //       would have two drawbacks:
+                    //       - we would test against the player ship itslef, if speed and ping
+                    //         is high enough (I tried to disable that collider, but that didn't work)
+                    //       - if multipe opponents collide, the first one we processed here
+                    //         would get maximal movement and the others would be cut short, which
+                    //         is not correct either...
+                    const int layerMask = (1<<(int)UnityObjectLayers.LEVEL) | (1<<(int)UnityObjectLayers.LAVA);
+                    RaycastHit hitInfo;
+                    Vector3 direction = (1.0f/dist) * deltaPos;
+
+                    if (Physics.SphereCast(basePos, radius, direction, out hitInfo, dist, layerMask, QueryTriggerInteraction.Ignore)) {
+                        // how far the ship's enclosing shpere dives into the collider
+                        float diveIn = dist - hitInfo.distance;
+                        // how far the ship's enclosing sphere is allowed to dive in
+                        float maxDive = (100.0f - (float)Menus.mms_lag_compensation_collision_limit)/50.0f * radius;
+                        if (diveIn > maxDive) {
+                            // limit the ship position
+                            diveIn = maxDive;
+                            newPos = basePos + (hitInfo.distance + diveIn) * direction;
+                        }
+                    }
+                }
+            }
+            player.c_player_ship.c_transform.localPosition = newPos;
             player.c_player_ship.c_transform.rotation = Quaternion.SlerpUnclamped(snapshot.m_rot, snapshot.m_rot*Quaternion.Euler(snapshot.m_vrot), t);
             player.c_player_ship.c_mesh_collider_trans.localPosition = player.c_player_ship.c_transform.localPosition;
         }

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -235,6 +235,7 @@ namespace GameMod {
                 Menus.mms_lag_compensation_ship_added_lag = ModPrefs.GetInt("MP_PM_LAG_COMPENSATION_SHIP_ADDED_LAG", Menus.mms_lag_compensation_ship_added_lag);
                 Menus.mms_ship_lag_compensation_scale = ModPrefs.GetInt("MP_PM_SHIP_LAG_COMPENSATION_SCALE", Menus.mms_ship_lag_compensation_scale);
                 Menus.mms_weapon_lag_compensation_scale = ModPrefs.GetInt("MP_PM_WEAPON_LAG_COMPENSATION_SCALE", Menus.mms_weapon_lag_compensation_scale);
+                Menus.mms_lag_compensation_collision_limit = ModPrefs.GetInt("MP_PM_SHIP_LAG_COMPENSATION_COLLISION_LIMIT", Menus.mms_lag_compensation_collision_limit);
                 Menus.mms_sticky_death_summary = ModPrefs.GetBool("MP_PM_STICKY_DEATH_SUMMARY", Menus.mms_sticky_death_summary);
                 MPDeathReview.stickyDeathReview = Menus.mms_sticky_death_summary;
                 Menus.mms_reduced_ship_explosions = ModPrefs.GetBool("MP_PM_REDUCED_SHIP_EXPLOSIONS", Menus.mms_reduced_ship_explosions);
@@ -292,6 +293,7 @@ namespace GameMod {
             ModPrefs.SetInt("MP_PM_LAG_COMPENSATION_SHIP_ADDED_LAG", Menus.mms_lag_compensation_ship_added_lag);
             ModPrefs.SetInt("MP_PM_WEAPON_LAG_COMPENSATION_SCALE", Menus.mms_weapon_lag_compensation_scale);
             ModPrefs.SetInt("MP_PM_SHIP_LAG_COMPENSATION_SCALE", Menus.mms_ship_lag_compensation_scale);
+            ModPrefs.SetInt("MP_PM_SHIP_LAG_COMPENSATION_COLLISION_LIMIT", Menus.mms_lag_compensation_collision_limit);
             ModPrefs.SetBool("MP_PM_STICKY_DEATH_SUMMARY", Menus.mms_sticky_death_summary);
             ModPrefs.SetBool("MP_PM_REDUCED_SHIP_EXPLOSIONS", Menus.mms_reduced_ship_explosions);
             ModPrefs.SetInt("MP_PM_DAMAGEEFFECT_ALPHA_MULT", Menus.mms_damageeffect_alpha_mult);

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -148,6 +148,7 @@ namespace GameMod {
             mms_lag_compensation_advanced = false;
             mms_lag_compensation_strength = 2;
             mms_lag_compensation_use_interpolation = 0;
+            mms_lag_compensation_collision_limit = 0;
         }
 
         public static int mms_weapon_lag_compensation_max = 100;
@@ -159,6 +160,7 @@ namespace GameMod {
         public static int mms_lag_compensation = 3;
         public static int mms_lag_compensation_strength = 2;
         public static int mms_lag_compensation_use_interpolation = 0;
+        public static int mms_lag_compensation_collision_limit = 0;
         public static string mms_mp_projdata_fn = "STOCK";
         public static bool mms_sticky_death_summary = false;
         public static int mms_damageeffect_alpha_mult = 30;
@@ -730,6 +732,9 @@ namespace GameMod {
                                 case 10:
                                     Menus.mms_lag_compensation_ship_added_lag = (int)(UIElement.SliderPos * 50f);
                                     break;
+                                case 11:
+                                    Menus.mms_lag_compensation_collision_limit = (int)(UIElement.SliderPos * 100f+0.5f);
+                                    break;
                                 case 100:
                                     MenuManager.PlaySelectSound(1f);
                                     m_menu_state_timer = 0f;
@@ -899,11 +904,11 @@ namespace GameMod {
             UIManager.ui_bg_dark = true;
             uie.DrawMenuBG();
             Vector2 position = uie.m_position;
-            position.y = UIManager.UI_TOP + 64f;
-            uie.DrawHeaderMedium(Vector2.up * (UIManager.UI_TOP + 30f), Loc.LS("LAG COMPENSATION SETTINGS"), 265f);
-            position.y += 20f;
+            position.y = UIManager.UI_TOP + 40f;
+            uie.DrawHeaderMedium(Vector2.up * (UIManager.UI_TOP + 25f), Loc.LS("LAG COMPENSATION SETTINGS"), 265f);
+            position.y += 12f;
             uie.DrawMenuSeparator(position);
-            position.y += 40f;
+            position.y += 32f;
             uie.SelectAndDrawStringOptionItem(Loc.LS("LAG COMPENSATION"), position, 1, Menus.GetMMSLagCompensation(), "ENABLE LAG COMPENSATION FOR MULTIPLAYER GAMES", 1.5f, false);
             position.y += 62f;
             uie.SelectAndDrawStringOptionItem(Loc.LS("USE ADVANCED SETTINGS"), position, 2, Menus.GetMMSLagCompensationAdvanced(), "SHOW ADVANCED SETTINGS TO FURTHER FINE TUNE YOUR LAG COMPENSATION", 1.5f, false);
@@ -933,8 +938,10 @@ namespace GameMod {
                 position.y += 62f;
                 SelectAndDrawSliderItem(uie, Loc.LS("SHIP LAG ADDED"), position, 10, Menus.mms_lag_compensation_ship_added_lag, 50, "ADDS A SET AMOUNT OF LAG TO THE END OF THE SHIP LAG COMPENSATION CALCULATIONS. USEFUL WHEN SHIP LAG COMPENSATION IS TURNED OFF." + Environment.NewLine + "A HIGHER SETTING WILL BETTER SHOW SHIP POSITIONS WITHOUT GUESSING, BUT REQUIRE YOU TO LEAD SHIPS MORE");
                 position.y += 62f;
+                SelectAndDrawSliderItem(uie, Loc.LS("LIMIT SHIPS DIVING INTO WALLS"), position, 11, Menus.mms_lag_compensation_collision_limit, 100, "LIMIT HOW FAR SHIPS MIGHT DIVE INTO WALLS (BUT SHIPS MIGHT APPEAR STUCK AT THE WALLS FOR SHORT MOMENTS INSTEAD)." + Environment.NewLine + "0 FOR UNLIMITED (NO CALCULATION OVERHEAD), OTHERWISE PERCENTAGE OF SHIP DIAMETER WHICH MUST REMAIN VISIBLE (100 = NO DIVE-IN AT ALL).");
+                position.y += 62f;
             }
-            position.y = UIManager.UI_BOTTOM - 120f;
+            position.y = UIManager.UI_BOTTOM - 118f;
             uie.DrawMenuSeparator(position);
             position.y += 5f;
             DrawMenuToolTipMultiline(uie, position, 15f);


### PR DESCRIPTION
This adds the new menu option "LIMIT SHIPS DIVING INTO WALLS" to the advanced lag compensation settings. If activated (>0), ship extrapolation will do an addition `SphereCast` to check whether extrapolation would place ships into walls (or lava), and limit the maximum dive-in range accordingly.

The menu option controls the percentage of the diameter of the ship's enclosing sphere which must always remain visible, setting it to 100 will prevent ships from diving in at all.

Drawback if this is activated:
* Ships will abruptly stop and appear "stuck" at the wall for short moments (instead of diving in further).
* Additional computational overhead if enabled (setting > 0), although  it did not make a noticeable difference in my tests. YMMV.

Default is 0, so people have to explicitly enable it if they want it.