### PR TITLE
Fix for intermittently empty Server Browser list

### DIFF
--- a/GameMod/MPServerBrowser.cs
+++ b/GameMod/MPServerBrowser.cs
@@ -108,7 +108,7 @@ namespace GameMod
                         ip = result.server.ip,
                         port = result.server.port,
                         name = result.server.name,
-                        version = result.server.version.Replace("olmod ", ""),
+                        version = result.server.version?.Replace("olmod ", ""),
                         serverNotes = result.server.serverNotes,
                         online = result.server.online,
                         gameStarted = result.game == null ? (DateTime?)null : result.game.gameStarted,


### PR DESCRIPTION
This problem manifested itself when OneEyedJohnny's server comes online - it must be old enough that there's no data flow for a version string to tracker -> server browser.  Server browser choked populating the server list doing a string replace on a null string

(Addresses Issue #174 )