### PR TITLE
Unload ambient sounds at level end

### DIFF
--- a/GameMod/AmbientUnload.cs
+++ b/GameMod/AmbientUnload.cs
@@ -1,0 +1,15 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace GameMod
+{
+    // Fix reloading custom ambient sounds by unloading them after the level ends
+    [HarmonyPatch(typeof(UnityAudio), "KillAllSounds")]
+    class AmbientUnload
+    {
+        static void Postfix(UnityAudio __instance) {
+            foreach (AudioSource src in __instance.m_ambient_sources)
+                src.clip.UnloadAudioData();
+        }
+    }
+}

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddOnLevelSort.cs" />
+    <Compile Include="AmbientUnload.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="Console.cs" />
     <Compile Include="Controllers.cs" />


### PR DESCRIPTION
This fixes missing custom ambient sounds when the level is restarted.