### PR TITLE
Don’t factor in ship movement to spawn invuln length

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -153,6 +153,7 @@
     <Compile Include="MPSmash.cs" />
     <Compile Include="MPSniperPackets.cs" />
     <Compile Include="MPSpawnInitialization.cs" />
+    <Compile Include="MPSpawnInvuln.cs" />
     <Compile Include="MPSpew.cs" />
     <Compile Include="MPSuddenDeath.cs" />
     <Compile Include="MPSuperCheck.cs" />

--- a/GameMod/MPSpawnInvuln.cs
+++ b/GameMod/MPSpawnInvuln.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using Overload;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace GameMod
+{
+
+    // Skip the portion in Player.UpdateInvul() where ship movement reduces your invuln time
+    [HarmonyPatch(typeof(Player), "UpdateInvul")]
+    internal class MPSpawnInvuln_Player_UpdateInvul
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            int state = 0;
+            foreach (var code in codes)
+            {
+                if (code.opcode == OpCodes.Stloc_1)
+                {
+                    state++;
+                    if (state == 2)
+                        code.opcode = OpCodes.Pop;
+                }
+
+                yield return code;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Skip the portion in Player.UpdateInvul() where ship movement reduces spawn invuln time