### PR TITLE
Reorganized processing of client-side team color changes

### DIFF
--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -384,6 +384,34 @@ namespace GameMod
                 newTeam = (MpTeam)reader.ReadPackedUInt32();
             }
         }
+
+        public static void UpdateClientColors()
+        {
+            if (GameplayManager.IsMultiplayerActive)
+            {
+                // Update ship colors
+                foreach (var ps in UnityEngine.Object.FindObjectsOfType<PlayerShip>())
+                {
+                    ps.UpdateShipColors(ps.c_player.m_mp_team, -1, -1, -1);
+                    ps.UpdateRimColor(true);
+                }
+
+                // Update CTF flag/carrier colors
+                if (CTF.IsActive)
+                {
+                    for (int i = 0; i < CTF.FlagObjs.Count; i++)
+                    {
+                        CTF.UpdateFlagColor(CTF.FlagObjs[i], i);
+                    }
+                    foreach (var player in Overload.NetworkManager.m_Players)
+                    {
+                        CTF.UpdateShipEffects(player);
+                    }
+                }
+            }
+            UIManager.InitMpNames();
+        }
+
     }
 
     [HarmonyPatch(typeof(UIElement), "MaybeDrawPlayerList")]
@@ -1383,6 +1411,9 @@ namespace GameMod
 
             if (player != null && msg.newTeam != player.m_mp_team)
             {
+                player.m_mp_team = msg.newTeam;
+                MPTeams.UpdateClientColors();
+
                 GameplayManager.AddHUDMessage($"{player.m_mp_name} changed teams", -1, true);
                 SFXCueManager.PlayRawSoundEffect2D(SoundEffect.hud_notify_message1);
             }

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -808,21 +808,21 @@ namespace GameMod {
                                     case 1:
                                         Menus.mms_team_color_default = !Menus.mms_team_color_default;
                                         MenuManager.PlaySelectSound(1f);
-                                        ProcessColorSelections();
+                                        MPTeams.UpdateClientColors();
                                         break;
                                     case 2:
                                         Menus.mms_team_color_self = (Menus.mms_team_color_self + 9 + UIManager.m_select_dir) % 9;
                                         if (Menus.mms_team_color_self == Menus.mms_team_color_enemy)
                                             Menus.mms_team_color_self = (Menus.mms_team_color_self + 9 + UIManager.m_select_dir) % 9;
                                         MenuManager.PlaySelectSound(1f);
-                                        ProcessColorSelections();
+                                        MPTeams.UpdateClientColors();
                                         break;
                                     case 3:
                                         Menus.mms_team_color_enemy = (Menus.mms_team_color_enemy + 9 + UIManager.m_select_dir) % 9;
                                         if (Menus.mms_team_color_enemy == Menus.mms_team_color_self)
                                             Menus.mms_team_color_enemy = (Menus.mms_team_color_enemy + 9 + UIManager.m_select_dir) % 9;
                                         MenuManager.PlaySelectSound(1f);
-                                        ProcessColorSelections();
+                                        MPTeams.UpdateClientColors();
                                         break;
                                 }
                                 break;
@@ -893,31 +893,6 @@ namespace GameMod {
             return false;
         }
 
-        static void ProcessColorSelections()
-        {
-            if (GameplayManager.IsMultiplayerActive)
-            {
-                // Update ship colors
-                foreach (var ps in UnityEngine.Object.FindObjectsOfType<PlayerShip>())
-                {
-                    ps.UpdateShipColors(ps.c_player.m_mp_team, -1, -1, -1);
-                    ps.UpdateRimColor(true);
-                }
-                // Update CTF flag/carrier colors
-                if (CTF.IsActive)
-                {
-                    for (int i = 0; i < CTF.FlagObjs.Count; i++)
-                    {
-                        CTF.UpdateFlagColor(CTF.FlagObjs[i], i);
-                    }
-                    foreach (var player in Overload.NetworkManager.m_Players)
-                    {
-                        CTF.UpdateShipEffects(player);
-                    }
-                }
-            }
-            UIManager.InitMpNames();
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Primary issue found was that clients could get the teamChange event for processing before the separate syncvar for the changed player's m_mp_team came through - new behavior is to not wait for the syncvar and set the m_mp_team locally/call the same code which gets called if client changes their color settings in the MP options