### PR TITLE
Sync PlayerShip mesh collider with the dying ship

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -135,6 +135,7 @@
     <Compile Include="MPDamageEffects.cs" />
     <Compile Include="MPDeathExplosion.cs" />
     <Compile Include="MPDeathReview.cs" />
+    <Compile Include="MPDeathRollSync.cs" />
     <Compile Include="MPErrorSmoothingFix.cs" />
     <Compile Include="MPFixGhostProjectiles.cs" />
     <Compile Include="MPHUDMessage.cs" />

--- a/GameMod/MPDeathRollSync.cs
+++ b/GameMod/MPDeathRollSync.cs
@@ -1,0 +1,15 @@
+﻿using HarmonyLib;
+using Overload;
+
+namespace GameMod
+{
+    [HarmonyPatch(typeof(PlayerShip), "FixedUpdatePreDying")]
+    class MPDeathRollSync_PlayerShip_FixedUpdatePreDying
+    {
+        static void Prefix(PlayerShip __instance)
+        {
+            if (GameplayManager.IsMultiplayerActive && __instance.c_mesh_collider_trans != null && __instance.c_transform != null)
+                __instance.c_mesh_collider_trans.localPosition = __instance.c_transform.localPosition;
+        }
+    }
+}


### PR DESCRIPTION
As presumed by roncli and others, the mesh collider for a dying ship is not updating while the ship death roll is in progress.  This addresses issue #195 