### PR TITLE
Add multiplayer chat commands and player bans.

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -124,7 +124,9 @@
     <Compile Include="MPAutomap.cs" />
     <Compile Include="MPAutoSelection.cs" />
     <Compile Include="MPAutoSelectionUI.cs" />
+    <Compile Include="MPBanPlayers.cs" />
     <Compile Include="MPCeiling.cs" />
+    <Compile Include="MPChatCommands.cs" />
     <Compile Include="MPClassic.cs" />
     <Compile Include="MPClientExtrapolation.cs" />
     <Compile Include="MPCloak.cs" />

--- a/GameMod/MPBanPlayers.cs
+++ b/GameMod/MPBanPlayers.cs
@@ -1,0 +1,389 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using Overload;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.Networking.NetworkSystem;
+
+namespace GameMod {
+    // the set of ban modes we support
+    public enum MPBanMode : int {
+        Ban=0,
+        Annoy,
+        Count // End Marker, always add before
+    }
+
+    // Class for entries of the ban list
+    // also used for candidate entries to check ban lists against
+    public class MPBanEntry {
+        public string name = null;
+        public string address = null;
+        public string id = null;
+        public bool permanent = false;
+        public DateTime timeCreated;
+
+        // generate MPBanEntry from individual entries
+        public MPBanEntry(string playerName, string connAddress, string playerId) {
+            Set(playerName, connAddress, playerId);
+        }
+
+        // generate MPBanEntry from name, connection_id and id
+        public MPBanEntry(string playerName, int connection_id, string playerId) {
+            Set(playerName, connection_id, playerId);
+        }
+
+        // generate MPBanEntry from a Player
+        public MPBanEntry(Player p) {
+            if (p != null) {
+                Set(p.m_mp_name, (p.connectionToClient != null)?p.connectionToClient.address:null, p.m_mp_player_id);
+            }
+        }
+
+        // generate MPBanEntry from a PlayerLobbyData
+        public MPBanEntry(PlayerLobbyData p) {
+            if (p != null) {
+                Set(p.m_name, p.m_id, p.m_player_id);
+            }
+        }
+
+        // Set MPBanEntry from individual entries
+        public void Set(string playerName, string connAddress, string playerId) {
+            name = (String.IsNullOrEmpty(playerName))?null:playerName.ToUpper();
+            address = (String.IsNullOrEmpty(connAddress))?null:connAddress.ToUpper().Trim();
+            id = (String.IsNullOrEmpty(playerId))?null:playerId.ToUpper().Trim();
+            timeCreated = DateTime.Now;
+        }
+
+        // Set MPBanEntry from name, connection_id, and id
+        public void Set(string playerName, int connection_id, string playerId) {
+            string addr=null;
+            if (connection_id >= 0 && connection_id < NetworkServer.connections.Count && NetworkServer.connections[connection_id] != null) {
+                addr = NetworkServer.connections[connection_id].address;
+            } else {
+                Debug.LogFormat("BAN ENTRY: failed to find connection for connection ID {0}", connection_id);
+            }
+            Set(playerName, addr, playerId);
+        }
+
+        // Set MPBanEntry from another entry
+        public void Set(MPBanEntry other) {
+            Set(other.name, other.address, other.id);
+            timeCreated = other.timeCreated;
+        }
+
+        // Describe the entry as human-readable string
+        public string Describe() {
+            return String.Format("(name {0}, addr {1}, ID {2})", name, address, id);
+        }
+
+        // check if the entry matches some player
+        public bool matches(MPBanEntry candidate, string prefix="") {
+            /* name isn't a good criteria, so ignore it
+            if (!String.IsNullOrEmpty(name) && !String.IsNullOrEmpty(candidate.name)) {
+                if (name == candidate.name) {
+                    Debug.LogFormat("{0}player {1} matches ban list entry {1} by NAME", prefix, candidate.Describe(), Describe());
+                    return true;
+                }
+
+            }*/
+            if (!String.IsNullOrEmpty(address) && !String.IsNullOrEmpty(candidate.address)) {
+                if (address == candidate.address) {
+                    Debug.LogFormat("{0}player {1} matches ban list entry {2} by ADDRESS", prefix, candidate.Describe(), Describe());
+                    return true;
+                }
+            }
+            if (!String.IsNullOrEmpty(id) && !String.IsNullOrEmpty(candidate.id)) {
+                if (id == candidate.id) {
+                    Debug.LogFormat("{0}player {1} matches ban list entry {2} by ID", prefix, candidate.Describe(), Describe());
+                    return true;
+                }
+            }
+
+            // does not match
+            return false;
+        }
+    }
+
+    // class for managing banned players
+    public class MPBanPlayers {
+        // this is the Ban List
+        private static List<MPBanEntry>[] banLists = new List<MPBanEntry>[(int)MPBanMode.Count];
+        private static int totalBanCount=0; // Count of bans in all lists
+        public static MPBanEntry MatchCreator = null; // description of the Game Creator
+
+        // Get the ban list
+        public static List<MPBanEntry> GetList(MPBanMode mode = MPBanMode.Ban) {
+            int m = (int)mode;
+            if (banLists[m] == null) {
+                banLists[m] = new List<MPBanEntry>();
+            }
+            return banLists[m];
+        }
+
+        // Check if this player is banned
+        public static bool IsBanned(MPBanEntry candidate, MPBanMode mode = MPBanMode.Ban) {
+            var banList=GetList(mode);
+            foreach (var entry in banList) {
+                if (entry.matches(candidate, "BAN CHECK: ")) {
+                    return true;
+                }
+            }
+            // no ban entry matches this player..
+            return false;
+        }
+
+        // Annoys a player
+        public static void AnnoyPlayer(Player p)
+        {
+            if (p != null) {
+                if (p.m_spectator == false) {
+                    p.m_spectator = true;
+                    Debug.LogFormat("BAN ANNOY player {0}",p.m_mp_name);
+                    if (p.connectionToClient != null) {
+                        MPChatTools.SendTo(String.Format("ANNOY BANNED player {0}",p.m_mp_name), -1, p.connectionToClient.connectionId);
+                    }
+                }
+            }
+        }
+
+        // Annoys all Players which are actively annoy-banned
+        // Doesn't work in the lobby
+        public static void AnnoyPlayers()
+        {
+            if (GetList(MPBanMode.Annoy).Count < 1) {
+                // no bans active
+                return;
+            }
+            foreach(var p in Overload.NetworkManager.m_Players) {
+                MPBanEntry candidate = new MPBanEntry(p);
+                if (IsBanned(candidate, MPBanMode.Annoy)) {
+                    AnnoyPlayer(p);
+                }
+            }
+        }
+
+        // Delayed disconnect on Kick
+        public static IEnumerator DelayedDisconnect(int connection_id)
+        {
+            yield return new WaitForSecondsRealtime(1);
+            if (connection_id < NetworkServer.connections.Count && NetworkServer.connections[connection_id] != null) {
+                NetworkServer.connections[connection_id].Disconnect();
+            }
+        }
+
+        // Kicks a player by a connection id. Also works in the Lobby
+        public static void KickPlayer(int connection_id, string name="")
+        {
+            if (connection_id < 0 || connection_id >= NetworkServer.connections.Count) {
+                return;
+            }
+            if (NetworkServer.connections[connection_id] != null) {
+                MPChatTools.SendTo(String.Format("KICKED player {0}",name), -1, connection_id);
+                //
+                NetworkServer.SendToClient(connection_id,51, new IntegerMessage(2000000000));
+                // SendPostGame(), prevents that the client immediately re-joins when in GAME
+                // (doesn't help in Lobby)
+                NetworkServer.SendToClient(connection_id,74, new IntegerMessage(0));
+                // Goodbye
+                //NetworkServer.connections[connection_id].Disconnect();
+                // disconnect it in an instant, to give client time to execute the commands
+                GameManager.m_gm.StartCoroutine(DelayedDisconnect(connection_id));
+            }
+
+        }
+
+        // Kicks an active Player
+        public static void KickPlayer(Player p)
+        {
+            if (p != null && p.connectionToClient != null) {
+                KickPlayer(p.connectionToClient.connectionId, p.m_mp_name);
+            }
+        }
+
+        // Kicks an Player in Lobby State
+        public static void KickPlayer(PlayerLobbyData p)
+        {
+            if (p != null) {
+                KickPlayer(p.m_id, p.m_name);
+            }
+        }
+
+        // Kicks all players who are BANNED (Lobby and otherwise)
+        public static void KickBannedPlayers()
+        {
+            if (GetList(MPBanMode.Ban).Count < 1) {
+                // no bans active
+                return;
+            }
+            MatchState s = NetworkMatch.GetMatchState();
+            bool inLobby = (s == MatchState.LOBBY || s == MatchState.LOBBY_LOAD_COUNTDOWN);
+            if (inLobby) {
+                // Kick Lobby Players
+                foreach (KeyValuePair<int, PlayerLobbyData> p in NetworkMatch.m_players) {
+                    if (p.Value != null) {
+                        MPBanEntry candidate = new MPBanEntry(p.Value);
+                        if (IsBanned(candidate, MPBanMode.Ban)) {
+                            KickPlayer(p.Value);
+                        }
+                    }
+                }
+            } else {
+                foreach(var p in Overload.NetworkManager.m_Players) {
+                    MPBanEntry candidate = new MPBanEntry(p);
+                    if (IsBanned(candidate, MPBanMode.Ban)) {
+                        KickPlayer(p);
+                    }
+                }
+            }
+        }
+
+        // Appy all bans to all all active players in Game
+        public static void ApplyAllBans()
+        {
+            if (totalBanCount < 1) {
+                return;
+            }
+            AnnoyPlayers();
+            KickBannedPlayers();
+        }
+
+        // The ban list was modified
+        public static void OnUpdate(MPBanMode mode, bool added)
+        {
+            totalBanCount = 0;
+            for (MPBanMode m = (MPBanMode)0; m < MPBanMode.Count; m++) {
+                totalBanCount += GetList(m).Count;
+            }
+            if (added) {
+                if (mode == MPBanMode.Annoy) {
+                    // apply Annoy bans directly, but not normal bans, as we have the specil KICK and KICKBAN commands
+                    // that way, we can ban players without having them to be immediately kicked
+                    AnnoyPlayers();
+                }
+            }
+        }
+
+        // Add a player to the Ban List
+        public static bool Ban(MPBanEntry candidate, MPBanMode mode = MPBanMode.Ban, bool permanent = false)
+        {
+            candidate.permanent = permanent;
+            var banList=GetList(mode);
+            foreach (var entry in banList) {
+                if (entry.matches(candidate, "BAN already matched: ")) {
+                    // Update it
+                    entry.Set(candidate);
+                    OnUpdate(mode, true);
+                    return false;
+                }
+            }
+            banList.Add(candidate);
+            Debug.LogFormat("BAN: player {0} is NOW banned in mode: {1}", candidate.Describe(), mode);
+            OnUpdate(mode, true);
+            return true;
+        }
+
+        // Remove all entries matching a candidate from the ban list
+        public static bool Unban(MPBanEntry candidate, MPBanMode mode = MPBanMode.Ban)
+        {
+            var banList = GetList(mode);
+            int cnt = banList.RemoveAll(entry => entry.matches(candidate,"UNBAN: "));
+            if (cnt > 0) {
+                OnUpdate(mode, false);
+                return true;
+            }
+            return false;
+        }
+
+        // Remove all bans
+        public static void UnbanAll(MPBanMode mode = MPBanMode.Ban) {
+            var banList = GetList(mode);
+            banList.Clear();
+            OnUpdate(mode, false);
+        }
+
+        // Remove all non-Permanent bans
+        public static void UnbanAllNonPermanent(MPBanMode mode = MPBanMode.Ban) {
+            var banList = GetList(mode);
+            banList.RemoveAll(entry => entry.permanent == false);
+            OnUpdate(mode, false);
+        }
+
+        // Reset the bans for the next game if a new player creates it
+        // Removes all non-permanent bans of all modes
+        public static void Reset() {
+            Debug.Log("MPBanPlayers: resetting all non-permanent bans");
+            for (MPBanMode mode = (MPBanMode)0; mode < MPBanMode.Count; mode++) {
+                UnbanAllNonPermanent(mode);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(NetworkMatch), "AcceptNewConnection")]
+    class MPBanPlayers_AcceptNewConnection {
+        // Delayed end game
+        public static IEnumerator DelayedEndMatch()
+        {
+            yield return new WaitForSecondsRealtime(3);
+            NetworkMatch.End();
+        }
+
+        private static void Postfix(ref bool __result, int connection_id, int version, string player_name, string player_session_id, string player_id, string player_uid) {
+            if (__result) {
+                // the player has been accepted by the game's matchmaking
+                MPBanEntry candidate = new MPBanEntry(player_name, connection_id, player_id);
+                bool isCreator = false;
+                if (!String.IsNullOrEmpty(NetworkMatch.m_name) && !String.IsNullOrEmpty(candidate.name)) {
+                    string creator = NetworkMatch.m_name.Split('\0')[0].ToUpper();
+                    if (creator == candidate.name) {
+                        isCreator = true;
+                    }
+                }
+                // check if player is banned
+                bool isBanned = MPBanPlayers.IsBanned(candidate);
+                if (isCreator && !isBanned) {
+                    // also check annoy-bans, annoy-banned players shall not create matches either
+                    // (although they can join games)
+                    isBanned = MPBanPlayers.IsBanned(candidate, MPBanMode.Annoy);
+                }
+                if (isBanned) {
+                    // banned player entered the lobby
+                    // NOTE: we cannot just say __accept = false, because this causes all sorts of troubles later
+                    MPBanPlayers.KickPlayer(connection_id, player_name);
+                    if (isCreator) {
+                        Debug.LogFormat("Creator for this match {0} is BANNED, ending match", candidate.name);
+                        GameManager.m_gm.StartCoroutine(DelayedEndMatch());
+                    }
+                } else {
+                    // unbanned player entered the lobby
+                    if (isCreator) {
+                        bool doReset = true;
+                        if (MPChatCommand.CheckPermission(candidate)) {
+                            Debug.Log("MPBanPlayers: same game creator as last match, or with permissions");
+                            doReset = false;
+                        }
+                        MPBanPlayers.MatchCreator = candidate;
+                        if (doReset) {
+                            Debug.Log("MPBanPlayers: new game creator, resetting bans and permissions");
+                            MPBanPlayers.Reset();
+                            MPChatCommand.Reset();
+                        } else {
+                            MPChatTools.SendTo(true, "keeping bans and permissions from previous match", connection_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Apply the bans when the match starts
+    [HarmonyPatch(typeof(NetworkMatch), "StartPlaying")]
+    class MPBanPlayers_OnStartPlaying {
+        private static void Postfix() {
+            MPBanPlayers.ApplyAllBans();
+        }
+    }
+}

--- a/GameMod/MPBanPlayers.cs
+++ b/GameMod/MPBanPlayers.cs
@@ -92,13 +92,13 @@ namespace GameMod {
             }*/
             if (!String.IsNullOrEmpty(address) && !String.IsNullOrEmpty(candidate.address)) {
                 if (address == candidate.address) {
-                    Debug.LogFormat("{0}player {1} matches ban list entry {2} by ADDRESS", prefix, candidate.Describe(), Describe());
+                    Debug.LogFormat("{0}player {1} matches entry {2} by ADDRESS", prefix, candidate.Describe(), Describe());
                     return true;
                 }
             }
             if (!String.IsNullOrEmpty(id) && !String.IsNullOrEmpty(candidate.id)) {
                 if (id == candidate.id) {
-                    Debug.LogFormat("{0}player {1} matches ban list entry {2} by ID", prefix, candidate.Describe(), Describe());
+                    Debug.LogFormat("{0}player {1} matches entry {2} by ID", prefix, candidate.Describe(), Describe());
                     return true;
                 }
             }
@@ -113,7 +113,13 @@ namespace GameMod {
         // this is the Ban List
         private static List<MPBanEntry>[] banLists = new List<MPBanEntry>[(int)MPBanMode.Count];
         private static int totalBanCount=0; // Count of bans in all lists
+
         public static MPBanEntry MatchCreator = null; // description of the Game Creator
+        public static string bannedName = " ** BANNED ** ";
+        public static bool JoiningPlayerIsBanned = false;
+        public static bool JoiningPlayerIsAnnoyed = false;
+        public static int  JoiningPlayerConnectionId = -1;
+        public static PlayerLobbyData JoiningPlayerLobbyData = null;
 
         // Get the ban list
         public static List<MPBanEntry> GetList(MPBanMode mode = MPBanMode.Ban) {
@@ -144,7 +150,7 @@ namespace GameMod {
                     p.m_spectator = true;
                     Debug.LogFormat("BAN ANNOY player {0}",p.m_mp_name);
                     if (p.connectionToClient != null) {
-                        MPChatTools.SendTo(String.Format("ANNOY BANNED player {0}",p.m_mp_name), -1, p.connectionToClient.connectionId);
+                        MPChatTools.SendTo(String.Format("ANNOY-BANNING player {0}",p.m_mp_name), -1, p.connectionToClient.connectionId, true);
                     }
                 }
             }
@@ -167,26 +173,30 @@ namespace GameMod {
         }
 
         // Delayed disconnect on Kick
+        static private MethodInfo _Server_OnDisconnect_Method = AccessTools.Method(typeof(Overload.Server), "OnDisconnect");
+
         public static IEnumerator DelayedDisconnect(int connection_id)
         {
             yield return new WaitForSecondsRealtime(1);
             if (connection_id < NetworkServer.connections.Count && NetworkServer.connections[connection_id] != null) {
-                NetworkServer.connections[connection_id].Disconnect();
+                NetworkConnection conn =  NetworkServer.connections[connection_id];
+                NetworkMessage msg = new NetworkMessage();
+                msg.conn = conn;
+                msg.msgType = 33; // Disconnect
+                _Server_OnDisconnect_Method.Invoke(null, new object[] { msg });
+                conn.Disconnect();
             }
         }
 
         // Kicks a player by a connection id. Also works in the Lobby
-        public static void KickPlayer(int connection_id, string name="")
+        public static void KickPlayer(int connection_id, string name="", bool banned = false)
         {
             if (connection_id < 0 || connection_id >= NetworkServer.connections.Count) {
                 return;
             }
             if (NetworkServer.connections[connection_id] != null) {
-                MPChatTools.SendTo(String.Format("KICKED player {0}",name), -1, connection_id);
-                //
-                NetworkServer.SendToClient(connection_id,51, new IntegerMessage(2000000000));
-                // SendPostGame(), prevents that the client immediately re-joins when in GAME
-                // (doesn't help in Lobby)
+                MPChatTools.SendTo(String.Format("KICKING {0}player {1}",((banned)?"BANNED ":""),name), -1, connection_id, true);
+                // SendPostGame(), prevents that the client immediately re-joins
                 NetworkServer.SendToClient(connection_id,74, new IntegerMessage(0));
                 // Goodbye
                 //NetworkServer.connections[connection_id].Disconnect();
@@ -197,18 +207,18 @@ namespace GameMod {
         }
 
         // Kicks an active Player
-        public static void KickPlayer(Player p)
+        public static void KickPlayer(Player p, bool banned = false)
         {
             if (p != null && p.connectionToClient != null) {
-                KickPlayer(p.connectionToClient.connectionId, p.m_mp_name);
+                KickPlayer(p.connectionToClient.connectionId, p.m_mp_name, banned);
             }
         }
 
         // Kicks an Player in Lobby State
-        public static void KickPlayer(PlayerLobbyData p)
+        public static void KickPlayer(PlayerLobbyData p, bool banned = false)
         {
             if (p != null) {
-                KickPlayer(p.m_id, p.m_name);
+                KickPlayer(p.m_id, p.m_name, banned);
             }
         }
 
@@ -227,7 +237,7 @@ namespace GameMod {
                     if (p.Value != null) {
                         MPBanEntry candidate = new MPBanEntry(p.Value);
                         if (IsBanned(candidate, MPBanMode.Ban)) {
-                            KickPlayer(p.Value);
+                            KickPlayer(p.Value, true);
                         }
                     }
                 }
@@ -235,7 +245,7 @@ namespace GameMod {
                 foreach(var p in Overload.NetworkManager.m_Players) {
                     MPBanEntry candidate = new MPBanEntry(p);
                     if (IsBanned(candidate, MPBanMode.Ban)) {
-                        KickPlayer(p);
+                        KickPlayer(p, true);
                     }
                 }
             }
@@ -287,15 +297,14 @@ namespace GameMod {
         }
 
         // Remove all entries matching a candidate from the ban list
-        public static bool Unban(MPBanEntry candidate, MPBanMode mode = MPBanMode.Ban)
+        public static int Unban(MPBanEntry candidate, MPBanMode mode = MPBanMode.Ban)
         {
             var banList = GetList(mode);
             int cnt = banList.RemoveAll(entry => entry.matches(candidate,"UNBAN: "));
             if (cnt > 0) {
                 OnUpdate(mode, false);
-                return true;
             }
-            return false;
+            return cnt;
         }
 
         // Remove all bans
@@ -312,7 +321,13 @@ namespace GameMod {
             OnUpdate(mode, false);
         }
 
-        // Reset the bans for the next game if a new player creates it
+        // Check if the MPBanPlayers has a non-default state
+        // This checks if any bans are present
+        public static bool HasModifiedState() {
+            return (totalBanCount > 0);
+        }
+
+        // Reset the MPBanPlayers state
         // Removes all non-permanent bans of all modes
         public static void Reset() {
             Debug.Log("MPBanPlayers: resetting all non-permanent bans");
@@ -322,6 +337,10 @@ namespace GameMod {
         }
     }
 
+    // Check the playe joining the lobby,
+    // Apply bans  and annoy-bans
+    // Also check if the joining player is the match creator,
+    // and reset bans and permissions accordingly for the new match.
     [HarmonyPatch(typeof(NetworkMatch), "AcceptNewConnection")]
     class MPBanPlayers_AcceptNewConnection {
         // Delayed end game
@@ -332,6 +351,10 @@ namespace GameMod {
         }
 
         private static void Postfix(ref bool __result, int connection_id, int version, string player_name, string player_session_id, string player_id, string player_uid) {
+            MPBanPlayers.JoiningPlayerIsBanned = false;
+            MPBanPlayers.JoiningPlayerIsAnnoyed = false;
+            MPBanPlayers.JoiningPlayerConnectionId = connection_id;
+            MPBanPlayers.JoiningPlayerLobbyData = null;
             if (__result) {
                 // the player has been accepted by the game's matchmaking
                 MPBanEntry candidate = new MPBanEntry(player_name, connection_id, player_id);
@@ -343,16 +366,16 @@ namespace GameMod {
                     }
                 }
                 // check if player is banned
-                bool isBanned = MPBanPlayers.IsBanned(candidate);
-                if (isCreator && !isBanned) {
-                    // also check annoy-bans, annoy-banned players shall not create matches either
-                    // (although they can join games)
-                    isBanned = MPBanPlayers.IsBanned(candidate, MPBanMode.Annoy);
+                MPBanPlayers.JoiningPlayerIsBanned = MPBanPlayers.IsBanned(candidate);
+                MPBanPlayers.JoiningPlayerIsAnnoyed = MPBanPlayers.IsBanned(candidate, MPBanMode.Annoy);
+                if (isCreator && MPBanPlayers.JoiningPlayerIsAnnoyed) {
+                    // annoyed players are treated as Banned for creating new matches
+                    MPBanPlayers.JoiningPlayerIsBanned = true;
                 }
-                if (isBanned) {
+                if (MPBanPlayers.JoiningPlayerIsBanned) {
                     // banned player entered the lobby
                     // NOTE: we cannot just say __accept = false, because this causes all sorts of troubles later
-                    MPBanPlayers.KickPlayer(connection_id, player_name);
+                    MPBanPlayers.KickPlayer(connection_id, player_name, true);
                     if (isCreator) {
                         Debug.LogFormat("Creator for this match {0} is BANNED, ending match", candidate.name);
                         GameManager.m_gm.StartCoroutine(DelayedEndMatch());
@@ -360,6 +383,7 @@ namespace GameMod {
                 } else {
                     // unbanned player entered the lobby
                     if (isCreator) {
+                        bool haveModifiedState = MPBanPlayers.HasModifiedState() || MPChatCommand.HasModifiedState();
                         bool doReset = true;
                         if (MPChatCommand.CheckPermission(candidate)) {
                             Debug.Log("MPBanPlayers: same game creator as last match, or with permissions");
@@ -370,12 +394,59 @@ namespace GameMod {
                             Debug.Log("MPBanPlayers: new game creator, resetting bans and permissions");
                             MPBanPlayers.Reset();
                             MPChatCommand.Reset();
+                            if (haveModifiedState) {
+                                MPChatTools.SendTo(true, "cleared all bans and permissions", connection_id);
+                            }
                         } else {
-                            MPChatTools.SendTo(true, "keeping bans and permissions from previous match", connection_id);
+                            if (haveModifiedState) {
+                                MPChatTools.SendTo(true, "keeping bans and permissions from previous match", connection_id);
+                            }
                         }
                     }
                 }
             }
+        }
+    }
+
+    // Don't send banned players in the lobby to other players
+    // rename ANNOY-BANNED players
+    [HarmonyPatch(typeof(Overload.Server), "SendPlayersInLobbyToAllClients")]
+    class MPBanPlayers_SendPlayersInLobbyToAllClients {
+        private static void Prefix() {
+            if (MPBanPlayers.JoiningPlayerConnectionId >= 0) {
+                if (MPBanPlayers.JoiningPlayerIsAnnoyed) {
+                    // rename annoy-banned players
+                    if (MPBanPlayers.JoiningPlayerIsAnnoyed) {
+                        foreach (KeyValuePair<int, PlayerLobbyData> p in NetworkMatch.m_players) {
+                            if (p.Key == MPBanPlayers.JoiningPlayerConnectionId) {
+                                if (p.Value != null) {
+                                    MPChatTools.SendTo(String.Format("ANNOY-BANNED player {0} joined, renamed to {1}",p.Value.m_name, MPBanPlayers.bannedName), -1, MPBanPlayers.JoiningPlayerConnectionId, true);
+                                    p.Value.m_name = MPBanPlayers.bannedName;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (MPBanPlayers.JoiningPlayerIsBanned) {
+                    if (NetworkMatch.m_players.ContainsKey(MPBanPlayers.JoiningPlayerConnectionId)) {
+                        // Save the PlayerLobbyData that we remove here, we add it back after SendPlayersInLobbyToAllClients
+                        MPBanPlayers.JoiningPlayerLobbyData = NetworkMatch.m_players[MPBanPlayers.JoiningPlayerConnectionId];
+                        NetworkMatch.m_players.Remove(MPBanPlayers.JoiningPlayerConnectionId);
+                    }
+                }
+            }
+        }
+
+        private static void Posfix() {
+            if (MPBanPlayers.JoiningPlayerIsBanned && MPBanPlayers.JoiningPlayerConnectionId >= 0 && MPBanPlayers.JoiningPlayerLobbyData != null) {
+                // Add back the PlayerLobbyData which we temporarily removed
+                NetworkMatch.m_players.Add(MPBanPlayers.JoiningPlayerConnectionId, MPBanPlayers.JoiningPlayerLobbyData);
+            }
+            // clear the JoiningPlayer ban state, everything is applied
+            MPBanPlayers.JoiningPlayerIsBanned = false;
+            MPBanPlayers.JoiningPlayerIsAnnoyed = false;
+            MPBanPlayers.JoiningPlayerConnectionId = -1;
+            MPBanPlayers.JoiningPlayerLobbyData = null;
         }
     }
 

--- a/GameMod/MPBanPlayers.cs
+++ b/GameMod/MPBanPlayers.cs
@@ -14,6 +14,7 @@ namespace GameMod {
     public enum MPBanMode : int {
         Ban=0,
         Annoy,
+        BlockChat,
         Count // End Marker, always add before
     }
 

--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -1,0 +1,658 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Overload;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace GameMod {
+    // Generic utility class for chat messages
+    public class MPChatTools {
+
+        // Send a chat message
+        // Set connection_id to the ID of a specific client, or to -1 to send to all
+        // clients except except_connection_id (if that is >= 0)
+        // You need to already know if we are currently in Lobby or not
+        public static bool SendTo(bool inLobby, string msg, int connection_id=-1 , int except_connection_id=-1, string sender_name = "Server", MpTeam team = MpTeam.TEAM0) {
+            bool toAll = (connection_id < 0);
+            if (!toAll) {
+                if (connection_id >= NetworkServer.connections.Count ||  NetworkServer.connections[connection_id] == null) {
+                    return false;
+                }
+            }
+
+            if (inLobby) {
+                var lmsg = new LobbyChatMessage(connection_id, sender_name, team, msg, false);
+                if (toAll) {
+                    if (except_connection_id < 0) {
+                        NetworkServer.SendToAll(75, lmsg);
+                    } else {
+                        foreach(NetworkConnection c in NetworkServer.connections) {
+                            if (c != null && c.connectionId != except_connection_id) {
+                                NetworkServer.SendToClient(c.connectionId, 75, lmsg);
+                            }
+                        }
+                    }
+                } else {
+                    NetworkServer.SendToClient(connection_id, 75, lmsg);
+                }
+            } else {
+                foreach (var p in Overload.NetworkManager.m_Players) {
+                    if (p != null && p.connectionToClient != null) {
+                        if ((toAll && p.connectionToClient.connectionId != except_connection_id) || (p.connectionToClient.connectionId == connection_id)) {
+                            p.CallTargetSendFullChat(p.connectionToClient, connection_id, sender_name, team, msg);
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        // Send a chat message
+        // Set connection_id to the ID of a specific client, or to -1 to send to all
+        // clients except except_connection_id (if that is >= 0)
+        public static bool SendTo(string msg, int connection_id=-1 , int except_connection_id=-1, string sender_name = "Server", MpTeam team = MpTeam.TEAM0) {
+            MatchState s = NetworkMatch.GetMatchState();
+            if (s == MatchState.NONE || s == MatchState.LOBBY_LOADING_SCENE) {
+                Debug.LogFormat("MPChatTools SendTo() called during match state {0}, ignored",s);
+                return false;
+            }
+            bool inLobby = (s == MatchState.LOBBY || s == MatchState.LOBBY_LOAD_COUNTDOWN);
+            return SendTo(inLobby, msg, connection_id, except_connection_id, sender_name, team);
+        }
+    }
+
+    // Class dealing with special chat commands
+    public class MPChatCommand {
+        // Enumeration of all defined Commands
+        public enum Command {
+            None, // not a known command
+            // List of Commands
+            GivePerm,
+            RevokePerm,
+            Kick,
+            Ban,
+            KickBan,
+            Unban,
+            Annoy,
+            Unannoy,
+            End,
+            Start,
+            Status,
+            Test,
+        }
+
+        // properties:
+        Command cmd;
+        public string cmdName;
+        public string arg;
+        public int sender_conn;
+        public bool needAuth;
+        public bool inLobby;
+        public MPBanEntry selectedPlayerEntry = null;
+        public Player selectedPlayer = null;
+        public PlayerLobbyData selectedPlayerLobbyData = null;
+        public int selectedPlayerConnectionId = -1;
+
+        // this Dictionary contains the set of authenticated players
+        // Authentication is done based on Player.m_player_id / PlayerLobbyData.m_player_id
+        private static Dictionary<string,bool> authenticatedConnections = new Dictionary<string,bool>();
+
+        // Check if chat commands are enabled.
+        public static bool IsEnabled()
+        {
+            // always enable them
+            // we might add some command-line argument to disable them, if a server op doesn't want this
+            return true;
+        }
+
+        // Construct a MPChatCommand from a Chat message
+        public MPChatCommand(string message, int sender_connection_id, bool isInLobby) {
+            cmd = Command.None;
+            sender_conn = sender_connection_id;
+            needAuth = false;
+            inLobby = isInLobby;
+
+            if (message == null || message.Length < 2 || message[0] != '/') {
+                // not a valid command
+                return;
+            }
+
+            // is there an additonal argument to this command?
+            // Arguments are separated with space
+            int split = message.IndexOf(' ');
+            if (split > 0) {
+                cmdName = message.Substring(1,split-1);
+                if (split + 1 < message.Length) {
+                    arg = message.Substring(split+1, message.Length - split -1);
+                }
+            } else {
+                cmdName = message.Substring(1,message.Length - 1);
+            }
+
+            // detect the command
+            cmdName = cmdName.ToUpper();
+            if (cmdName == "GP" || cmdName == "GIVEPERM") {
+                cmd = Command.GivePerm;
+                needAuth = true;
+            } else if (cmdName == "RP" || cmdName == "REVOKEPERM") {
+                cmd = Command.RevokePerm;
+                needAuth = true;
+            } else if (cmdName == "K" || cmdName == "KICK") {
+                cmd = Command.Kick;
+                needAuth = true;
+            } else if (cmdName == "B" || cmdName == "BAN") {
+                cmd = Command.Ban;
+                needAuth = true;
+            } else if (cmdName == "A" || cmdName == "ANNOY") {
+                cmd = Command.Annoy;
+                needAuth = true;
+            } else if (cmdName == "UA" || cmdName == "UNANNOY") {
+                cmd = Command.Unannoy;
+                needAuth = true;
+            } else if (cmdName == "KB" || cmdName == "KICKBAN") {
+                cmd = Command.KickBan;
+                needAuth = true;
+            } else if (cmdName == "UB" || cmdName == "UNBAN") {
+                cmd = Command.Unban;
+                needAuth = true;
+            } else if (cmdName == "E" || cmdName == "END") {
+                cmd = Command.End;
+                needAuth = true;
+            } else if (cmdName == "S" || cmdName == "START") {
+                cmd = Command.Start;
+                needAuth = true;
+            } else if (cmdName == "STATUS") {
+                cmd = Command.Status;
+            } else if (cmdName == "T" || cmdName == "TEST") {
+                cmd = Command.Test;
+            }
+        }
+
+        // Execute a command: Returns true if the caller should forward the chat message
+        // to the clients, and false if not (when it was a special command for the server)
+        public bool Execute() {
+            if (!IsEnabled()) {
+                // chat commands are not enabled
+                return true;
+            }
+
+            if (cmd == Command.None) {
+                // there might be Annoy-Banned players, and we can just ignore their ramblings
+                if (MPBanPlayers.GetList(MPBanMode.Annoy).Count > 0) {
+                    MPBanEntry we = FindPlayerEntryForConnection(sender_conn, inLobby);
+                    if (we != null && MPBanPlayers.IsBanned(we, MPBanMode.Annoy)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            Debug.LogFormat("CHATCMD {0}: {1} {2}", cmd, cmdName, arg);
+            if (needAuth) {
+                if (!CheckPermission()) {
+                    ReturnToSender(String.Format("You do not have the permission for command {0}!", cmd));
+                    Debug.LogFormat("CHATCMD {0}: client is not authenticated!", cmd);
+                    return false;
+                }
+            }
+            bool result = false;
+            switch (cmd) {
+                case Command.GivePerm:
+                    result = DoPerm(true);
+                    break;
+                case Command.RevokePerm:
+                    result = DoPerm(false);
+                    break;
+                case Command.Kick:
+                    result = DoKickBan(true, false, MPBanMode.Ban);
+                    break;
+                case Command.Ban:
+                    result = DoKickBan(false, true, MPBanMode.Ban);
+                    break;
+                case Command.Annoy:
+                    result = DoKickBan(false, true, MPBanMode.Annoy);
+                    break;
+                case Command.KickBan:
+                    result = DoKickBan(true, true, MPBanMode.Ban);
+                    break;
+                case Command.Unban:
+                    result = DoUnban(MPBanMode.Ban);
+                    break;
+                case Command.Unannoy:
+                    result = DoUnban(MPBanMode.Annoy);
+                    break;
+                case Command.End:
+                    result = DoEnd();
+                    break;
+                case Command.Start:
+                    result = DoStart();
+                    break;
+                case Command.Status:
+                    result = DoStatus();
+                    break;
+                case Command.Test:
+                    result = DoTest();
+                    break;
+                default:
+                    Debug.LogFormat("CHATCMD {0}: {1} {2} was not handled by server", cmd, cmdName, arg);
+                    result = true; // treat it as normal chat message
+                    break;
+            }
+            return result;
+        }
+
+        // set authentication status of player by id
+        public static bool SetAuth(bool allowed, string id)
+        {
+            if (String.IsNullOrEmpty(id)) {
+                Debug.LogFormat("SETAUTH callid without valid player id");
+                return false;
+            }
+
+            if (allowed) {
+                Debug.LogFormat("AUTH: client {0} is authenticated", id);
+                if (!authenticatedConnections.ContainsKey(id)) {
+                    authenticatedConnections.Add(id, true);
+                }
+            } else {
+                // de-auth
+                Debug.LogFormat("AUTH: client {0} is NOT authenticated", id);
+                if (authenticatedConnections.ContainsKey(id)) {
+                    authenticatedConnections.Remove(id);
+                }
+            }
+            return true;
+        }
+
+        // Execute GIVEPERM/REVOKEPERM command
+        public bool DoPerm(bool give)
+        {
+            string op = (give)?"GIVEPERM":"REVOKEPERM";
+            if (!SelectPlayer(arg)) {
+                if (give) {
+                    Debug.LogFormat("{0}: no player {1} found", op, arg);
+                    ReturnToSender(String.Format("{0}: player {1} not found",op, arg));
+                    return false;
+                } else {
+                    authenticatedConnections.Clear();
+                    Debug.LogFormat("{0}: all client permissions revoked", op, arg);
+                    ReturnToSender(String.Format("{0}: all client permissions revoked",op));
+                }
+            }
+
+            if (SetAuth(give, selectedPlayerEntry.id)) {
+                ReturnToSender(String.Format("{0}: player {1} applied",op,selectedPlayerEntry.name));
+                if (selectedPlayerConnectionId >= 0) {
+                    ReturnTo(String.Format("You have been {0} CHAT COMMAND permissions.",(give)?"granted":"revoked"),selectedPlayerConnectionId);
+                }
+            } else {
+                ReturnToSender(String.Format("{0}: player {1} failed",op,selectedPlayerEntry.name));
+            }
+
+            return false;
+        }
+
+        // Execute KICK or BAN or KICKBAN or ANNOY command
+        public bool DoKickBan(bool doKick, bool doBan, MPBanMode banMode) {
+            string op;
+            string banOp = banMode.ToString().ToUpper();
+            if (doKick && doBan) {
+                op = "KICK" + banOp;
+            } else if (doKick) {
+                op = "KICK";
+            } else if (doBan) {
+                op = banOp;
+            } else {
+                return false;
+            }
+
+            Debug.LogFormat("{0} request for {1}", op, arg);
+            if (!SelectPlayer(arg)) {
+                Debug.LogFormat("{0}: no player {1} found", op, arg);
+                ReturnToSender(String.Format("{0}: player {1} not found",op, arg));
+                return false;
+            }
+
+            if(selectedPlayerConnectionId >= 0 && sender_conn == selectedPlayerConnectionId) {
+                Debug.LogFormat("{0}: won't self-apply", op, arg);
+                ReturnToSender(String.Format("{0}: won't self-apply",op, arg));
+                return false;
+            }
+
+            if (doBan) {
+                MPBanPlayers.Ban(selectedPlayerEntry, banMode);
+                ReturnTo(String.Format("{0} player {1}", banOp, selectedPlayerEntry.name), -1, selectedPlayerConnectionId);
+            }
+            if (doKick) {
+                if (selectedPlayer != null) {
+                    MPBanPlayers.KickPlayer(selectedPlayer);
+                } else if (selectedPlayerLobbyData != null) {
+                    MPBanPlayers.KickPlayer(selectedPlayerLobbyData);
+                } else {
+                    MPBanPlayers.KickPlayer(selectedPlayerConnectionId, selectedPlayerEntry.name);
+                }
+            }
+            return false;
+        }
+
+        // Execute UNBAN or UNANNOY
+        public bool DoUnban(MPBanMode banMode)
+        {
+            if (String.IsNullOrEmpty(arg)) {
+                MPBanPlayers.UnbanAll(banMode);
+                ReturnTo(String.Format("ban list {0} has been cleared",banMode));
+            } else {
+                string pattern = arg.ToUpper();
+                var banList=MPBanPlayers.GetList(banMode);
+                int cnt = banList.RemoveAll(entry => (MatchPlayerName(entry.name, pattern) != 0));
+                MPBanPlayers.OnUpdate(banMode, false);
+                ReturnTo(String.Format("{0} players have been UNBANNED from {1} list", cnt, banMode));
+            }
+            return false;
+        }
+
+        // Execute END command
+        public bool DoEnd()
+        {
+            Debug.Log("END request via chat command");
+            ReturnTo("manual match END request");
+            NetworkMatch.End();
+            return false;
+        }
+
+        // Execute START commad
+        public bool DoStart()
+        {
+            if (!inLobby) {
+                Debug.LogFormat("START request via chat command ignored in non-LOBBY state");
+                ReturnTo("START: not possible because I'm not in the Lobby");
+                return false;
+            }
+            Debug.LogFormat("START request via chat command");
+            ReturnTo("manual match START request");
+            MPChatCommands_ModifyLobbyStartTime.StartMatch = true;
+            return false;
+        }
+
+        // Execute STATUS command
+        public bool DoStatus()
+        {
+            string creator;
+            if (MPBanPlayers.MatchCreator != null && !String.IsNullOrEmpty(MPBanPlayers.MatchCreator.name)) {
+                creator = MPBanPlayers.MatchCreator.name;
+            } else {
+                creator = "<UNKNOWN>";
+            }
+
+            ReturnToSender(String.Format("STATUS: {0}'s game, your auth: {1}", creator,CheckPermission()));
+            ReturnToSender(String.Format("STATUS: bans: {0}, annoy-bans: {1}, authList: {2}",
+                                         MPBanPlayers.GetList(MPBanMode.Ban).Count,
+                                         MPBanPlayers.GetList(MPBanMode.Annoy).Count,
+                                         authenticatedConnections.Count));
+            return false;
+        }
+
+        // Execute TEST command
+        public bool DoTest()
+        {
+            Debug.LogFormat("TEST request for {0}", arg);
+            if (!SelectPlayer(arg)) {
+                ReturnToSender(String.Format("did not find player {0}",arg));
+                return false;
+            }
+            ReturnToSender(String.Format("found player {0}",selectedPlayerEntry.name));
+            return false;
+        }
+
+        // Send a chat message back to the sender of the command
+        // HA: An Elvis reference!
+        public bool ReturnToSender(string msg) {
+            return MPChatTools.SendTo(inLobby, msg, sender_conn);
+        }
+
+        // Send a chat message to all clients except the given connection id, -1 for all
+        public bool ReturnTo(string msg, int connection_id = -1, int except_connection_id = -1) {
+            return MPChatTools.SendTo(inLobby, msg, connection_id, except_connection_id);
+        }
+
+        // Select a player by a pattern
+        public bool SelectPlayer(string pattern) {
+            selectedPlayerEntry = null;
+            selectedPlayer = null;
+            selectedPlayerLobbyData = null;
+            selectedPlayerConnectionId = -1;
+            if (inLobby) {
+                selectedPlayerLobbyData = FindPlayerInLobby(pattern);
+                if (selectedPlayerLobbyData != null) {
+                    selectedPlayerEntry = new MPBanEntry(selectedPlayerLobbyData);
+                    selectedPlayerConnectionId = selectedPlayerLobbyData.m_id;
+                    if (selectedPlayerConnectionId >= NetworkServer.connections.Count) {
+                        selectedPlayerConnectionId = -1;
+                    }
+                    return true;
+                }
+            } else {
+                selectedPlayer = FindPlayer(pattern);
+                if (selectedPlayer != null) {
+                    selectedPlayerEntry = new MPBanEntry(selectedPlayer);
+                    selectedPlayerConnectionId = (selectedPlayer.connectionToClient!=null)?selectedPlayer.connectionToClient.connectionId:-1;
+                    if (selectedPlayerConnectionId >= NetworkServer.connections.Count) {
+                        selectedPlayerConnectionId = -1;
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Find the player ID string based on a connection ID
+        public string FindPlayerIDForConnection(int conn_id, bool inLobby) {
+            MPBanEntry entry = FindPlayerEntryForConnection(conn_id, inLobby);
+            if (entry != null && !String.IsNullOrEmpty(entry.id)) {
+                return entry.id;
+            }
+            return "";
+        }
+
+        // Find the player name string based on a connection ID
+        public string FindPlayerNameForConnection(int conn_id, bool inLobby) {
+            MPBanEntry entry = FindPlayerEntryForConnection(conn_id, inLobby);
+            if (entry != null && !String.IsNullOrEmpty(entry.name)) {
+                return entry.name;
+            }
+            return "";
+        }
+
+        // Make a MPBanEntry candidate from a connection ID
+        public MPBanEntry FindPlayerEntryForConnection(int conn_id, bool inLobby) {
+            if (inLobby) {
+                foreach (KeyValuePair<int, PlayerLobbyData> p in NetworkMatch.m_players) {
+                    if (p.Value != null && p.Value.m_id == conn_id) {
+                        return new MPBanEntry(p.Value);
+                    }
+                }
+            } else {
+                foreach (var p in Overload.NetworkManager.m_Players) {
+                    if (p != null && p.connectionToClient != null && p.connectionToClient.connectionId == conn_id) {
+                        return new MPBanEntry(p);
+                    }
+                }
+            }
+            return null;
+        }
+
+        // check if a specific player has chat command permissions
+        public static bool CheckPermission(MPBanEntry entry) {
+            if (entry == null) {
+                return false;
+            }
+            if (MPBanPlayers.MatchCreator != null && entry.matches(MPBanPlayers.MatchCreator)) {
+                // the match creator is always authenticated
+                return true;
+            }
+
+            if (String.IsNullOrEmpty(entry.id)) {
+                Debug.LogFormat("CheckPermission: failed to get player ID");
+                return false;
+            }
+            return (authenticatedConnections.ContainsKey(entry.id) && authenticatedConnections[entry.id] == true);
+        }
+
+        // Check if the sender of the message is authenticated
+        public bool CheckPermission() {
+            MPBanEntry entry = FindPlayerEntryForConnection(sender_conn, inLobby);
+            if (entry == null) {
+                Debug.LogFormat("CheckPermission: failed to query player for connection {0}", sender_conn);
+                return false;
+            }
+            return CheckPermission(entry);
+        }
+
+        // Match string name version pattern,
+        // Allow '?' as wildcard character in pattern, matches every character
+        public static int MatchIndexOf(string name, string pattern) {
+            int nLen = name.Length;
+            int pLen = pattern.Length;
+            int cnt;
+            int i,j;
+            cnt = nLen - pLen + 1;
+
+            if (pLen < 1) {
+                // empty pattern matches everything
+                return 0;
+            }
+
+            for (i=0; i < cnt; i++) {
+                bool matches = true;
+                for (j=0; j<pLen; j++) {
+                    if ( (pattern[j] != '?') && (pattern[j] != name[i+j])) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (matches) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        // Match a player name versus the player name pattern
+        // Return 1 on perfect match
+        //        0 on no match at all
+        // or a negative value with lower value meaning worse match
+        public int MatchPlayerName(string name, string pattern)
+        {
+            if (String.IsNullOrEmpty(name)) {
+                // no match possible
+                return 0;
+            }
+
+            if (name == pattern) {
+                // perfect match
+                return 1;
+            }
+
+            int index = MatchIndexOf(name, pattern);
+            if (index >= 0) {
+               int extraChars = name.Length - pattern.Length + 1;
+               // the earlier the match, the better is the score,
+               // the less extra chars, the better the the score
+               return -extraChars -(index*100);
+
+            }
+            return 0;
+        }
+
+        // Find the best match for a player
+        // Search the active players in game
+        // May return null if no match can be found
+        public Player FindPlayer(string pattern) {
+            if (String.IsNullOrEmpty(pattern)) {
+                return null;
+            }
+
+            int bestScore = -1000000000;
+            Player bestPlayer = null;
+            pattern = pattern.ToUpper();
+
+            foreach (var p in Overload.NetworkManager.m_Players) {
+                int score = MatchPlayerName(p.m_mp_name.ToUpper(), pattern);
+                if (score > 0) {
+                    return p;
+                }
+                if (score < 0 && score > bestScore) {
+                    bestScore = score;
+                    bestPlayer = p;
+                }
+            }
+            if (bestPlayer == null) {
+                Debug.LogFormat("CHATCMD: did not find a player matching {0}", pattern);
+            }
+            return bestPlayer;
+        }
+
+        // Find the best match for a player
+        // Search the active players in the lobby
+        // May return null if no match can be found
+        public PlayerLobbyData FindPlayerInLobby(string pattern) {
+            if (String.IsNullOrEmpty(pattern)) {
+                return null;
+            }
+
+            int bestScore = -1000000000;
+            PlayerLobbyData bestPlayer = null;
+            pattern = pattern.ToUpper();
+
+            foreach (KeyValuePair<int, PlayerLobbyData> p in NetworkMatch.m_players) {
+                int score = MatchPlayerName(p.Value.m_name.ToUpper(), pattern);
+                if (score > 0) {
+                    return p.Value;
+                }
+                if (score < 0 && score > bestScore) {
+                    bestScore = score;
+                    bestPlayer = p.Value;
+                }
+            }
+            if (bestPlayer == null) {
+                Debug.LogFormat("CHATCMD: did not find a player matching {0}", pattern);
+            }
+            return bestPlayer;
+        }
+
+        // Reset the state of the chat commands
+        // This clears all authentications
+        public static void Reset() {
+            Debug.Log("MPChatCommands: clearing command authentications");
+            authenticatedConnections.Clear();
+        }
+    }
+
+    [HarmonyPatch(typeof(NetworkMatch), "ProcessLobbyChatMessageOnServer")]
+    class MPChatCommands_ProcessLobbyMessage {
+        private static bool Prefix(int sender_connection_id, LobbyChatMessage msg) {
+            MPChatCommand cmd = new MPChatCommand(NetworkMessageManager.StripTeamPrefix(msg.m_text), sender_connection_id, true);
+            return cmd.Execute();
+        }
+    }
+
+    [HarmonyPatch(typeof(Player), "CmdSendFullChat")]
+    class MPChatCommands_ProcessIngameMessage {
+        private static bool Prefix(int sender_connection_id, string sender_name, MpTeam sender_team, string msg) {
+            MPChatCommand cmd = new MPChatCommand(msg, sender_connection_id, false);
+            return cmd.Execute();
+        }
+    }
+
+    [HarmonyPatch(typeof(NetworkMatch), "NetSystemHostGetLobbyInformation")]
+    class MPChatCommands_ModifyLobbyStartTime {
+        public static bool StartMatch = false;
+        private static void Postfix(ref NetworkMatch.HostLobbyInformation __result, object hai) {
+            if (hai != null && StartMatch) {
+                __result.ForceMatchStartTime = DateTime.Now;
+                StartMatch = false;
+            }
+        }
+    }
+}

--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -271,7 +271,7 @@ namespace GameMod {
             if (!GameMod.Core.GameMod.FindArgVal("-trustedPlayerIds", out idstring) && String.IsNullOrEmpty(idstring)) {
                 return; // no trustedPlayerIds specified;
             }
-            string[] ids = idstring.Split(';');
+            string[] ids = idstring.Split(',',';',':','|');
             foreach (string id in ids) {
                 MPBanEntry entry = new MPBanEntry(null, null, id);
                 if (entry.IsValid()) {

--- a/GameMod/MPJoinInProgress.cs
+++ b/GameMod/MPJoinInProgress.cs
@@ -379,6 +379,14 @@ namespace GameMod {
         private static IEnumerator MatchStart(int connectionId)
         {
             var newPlayer = Server.FindPlayerByConnectionId(connectionId);
+            MPBanEntry newPlayerEntry = new MPBanEntry(newPlayer);
+
+            // prevent banned players from JIP into our match
+            // there is already a delayed Disconnect going on, just
+            // prevent this player from entering the JIP code
+            if (MPBanPlayers.IsBanned(newPlayerEntry)) {
+                yield break;
+            }
 
             float pregameWait = 3f;
 

--- a/GameMod/MPJoinInProgress.cs
+++ b/GameMod/MPJoinInProgress.cs
@@ -453,6 +453,7 @@ namespace GameMod {
                 });
             }
             ServerStatLog.Connected(newPlayer.m_mp_name);
+            MPBanPlayers.ApplyAllBans(); // make sure the newly connected player gets proper treatment if he is BANNED
         }
 
         private static void Postfix(NetworkMessage msg)

--- a/GameMod/MPSniperPackets.cs
+++ b/GameMod/MPSniperPackets.cs
@@ -675,7 +675,7 @@ namespace GameMod
             var msg = rawMsg.ReadMessage<SniperPacketMessage>();
             var player = Overload.NetworkManager.m_Players.Find(p => p.netId == msg.m_player_id);
 
-            if (player == null || player.c_player_ship.m_dead || player.c_player_ship.m_dying)
+            if (player == null || player.c_player_ship.m_dead || player.c_player_ship.m_dying || player.m_spectator)
             {
                 return;
             }

--- a/ServerCommands.md
+++ b/ServerCommands.md
@@ -1,0 +1,60 @@
+# Multiplayer Server Commands
+
+Olmod adds the ability to send commands from any connected client to the dedicated server via the multiplayer chat functionality.
+Most of the commands need special privileges. By default, the creator of a match has these chat command permissions,
+see [the section on privilege management below](#privilege-management) for details.
+
+## List of available Commands
+
+ * `/KICK <player>`: Kick a player from the server. Player can still reconnect.
+ * `/BAN <player>`: Ban player from the server, prevents the player from joining (or creating new matches), but does not immediately disconnect the client.
+ * `/KICKBAN <player>`: Kick and Ban a player.
+ * `/ANNOY <player>`: Annoy-Ban player: Player is put into spectator state on server, and also implies `/BLOCKCHAT` so player's chat messages are suppressed.
+ * `/UNBAN [<player>]`: Unban specific player or all banned players.
+ * `/UNANNOY [<player>]`: Remove the annoy-bans for a player or all annoy-banned players. Note that an annoy-banned player needs to re-join before the all of the effects are removed. This implies `/UNBLOCKCHAT`.
+ * `/BLOCKCHAT <player>`: Block all chat messages from the specified player on the server, do not relay them to the other clients. This is a ban and will still apply if a player re-connects.
+ * `/UNBLOCKCHAT [<player>]`: Remove the block-chat ban for a player or all players.
+ * `/START`: Start the match immediately (when in lobby)
+ * `/END`: End the match immediately
+ * `/GIVEPERM <player>`: grant a player the chat command permissions.
+ * `/REVOKEPERM [<player>]`: revoke chat command permissions from a player or all players.
+ * `/AUTH password`: a server operator can also start the server with the commandline argument `-chatCommandPassword serverPassword`. Any Player knowing this password can get to authenticated state with this command. If no `serverPassword` is set, this command always fails. Note that the password check is **not** case-sensitive.
+ * `/STATUS`: short info about chat command and ban status. No permission required for this command.
+ * `/SAY`: send a message to all players which are not blocked for chat
+ * `/TEST <player>`: Test player name selection. No permission required for this command.
+
+### Player Name Matching
+
+Player names are matches the `<player>` pattern as follows:
+ * If the name matches completely, that player is selected
+ * If only one player name contains the pattern, that player is selected.
+ * If several player names contain the pattern:
+   * The one player where the pattern matches earlier in the name is selected
+   * It the pattern starts at the same position for multiply players, the one with the least number of extra characters in the rest of the not-matched part of the string is selected
+ * The `<player>` pattern contain `?` as wildcard character, matching every possible character (including non-typable unicode ones). You can use the `/TEST` command to check which player would be selected.
+ * Spaces are allowed in the `<player>` pattern. Everything after the first space character separating the command from the argument is used as-is.
+
+## Privilege Management
+
+The person who initially created the match has always permission to use the chat commands. Further players can be added by using the `/GIVEPERM` command, 
+and revoked with `/REVOKEPERM`. If the server operator specified a chat command password, any player knowing the password can also self-authenticate 
+via `/AUTH` command.
+
+### Persistence of bans and privileges
+
+The bans and command privileges stay effective until a new game is created on the server _by a different, unbanned person_.
+Bans and permissions are not persistently stored - if the server process is restarted, all bans and permissions are reset.
+
+If a match is created by the same creator as before, or a player who has chat command privileges, the match creator is informed
+by the server that all bans and permissions were kept. If a new match is created by any other player, the match creator is informed
+that all bans and permissions were reset _if_ any bans and permissions were active before.
+
+Players can always use the `/STATUS` command to check whether bans or chat permissions are active. This command does not require any permissions.
+
+## Command Line Options for controlling chat commands
+
+Server operators can further control the chat commands via commandline arguments:
+ * `-disableChatCommands` will disable all chat commands on this server
+ * `-trustedPlayerIds id1[,...,idN]` will add the specified player IDs (sepatated by comma, colon or semicolon) as _trusted players_. Trusted Players always have chat command permission, and can not be kicked or banned from the server. Note that the player IDs are **not** player names. Server operators can find the player IDs in the server log file.
+ * `-chatCommandPassword serverPassword` will allow players knowing the password to authenticate themselves with the `/AUTH` command.
+


### PR DESCRIPTION
[NOTE: This PR is based against the v0.5.5 branch, I can also prepare it for master if neccessary.]

This patch adds code infrastructure for server-side commands via the multiplayer chat, as well as a basic system for banning players (hello, Elvis!). Commands can be sent to the server via the `/COMMAND [argument]` syntax. The feature is described in detail in the [`ServerCommands.md` file](https://github.com/derhass/olmod/blob/features/chat_commands/ServerCommands.md)