### PR TITLE
Auto-download code overhaul

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -145,6 +145,7 @@
     <Compile Include="MPHUDMessage.cs" />
     <Compile Include="MPIPLogging.cs" />
     <Compile Include="MPItemSpawns.cs" />
+    <Compile Include="MPDownloadLevelAlgorithm.cs" />
     <Compile Include="MPLongPwd.cs" />
     <Compile Include="MPMatchPresets.cs" />
     <Compile Include="MPMatchTimeLimits.cs" />

--- a/GameMod/MPDownloadLevel.cs
+++ b/GameMod/MPDownloadLevel.cs
@@ -93,6 +93,8 @@ namespace GameMod
             public string ZipPath => level.ZipPath;
 
             public string FilePath => level.FilePath;
+
+            public string IdStringHash => level.GetAddOnLevelIdStringHash();
         }
 
         private static void AddMPLevel(string filename)

--- a/GameMod/MPDownloadLevel.cs
+++ b/GameMod/MPDownloadLevel.cs
@@ -43,7 +43,11 @@ namespace GameMod {
             }
         }
 
-        // same algorithm as Mission.AddAddOnLevel
+        /// <summary>
+        /// Finds the index of a given level in the provided level list. Checks level file name and
+        /// display name; does not guarantee matching contents.
+        /// Same algorithm as Mission.AddAddOnLevel
+        /// </summary>
         private static int FindLevelIndex(List<LevelInfo> levels, string levelIdHash)
         {
             string fileNameExt = levelIdHash.Split(new[] { ':' })[0];
@@ -64,6 +68,12 @@ namespace GameMod {
             return _Mission_Levels_Field.GetValue(GameManager.MultiplayerMission) as List<LevelInfo>;
         }
 
+        /// <summary>
+        /// Returns the path of a loaded multiplayer level that matches the filename from the given level ID hash,
+        /// regardless of whether the version matches. Also returns a reference to the level list and position of
+        /// the matching level within that list.
+        /// Returns null if no matching level is loaded.
+        /// </summary>
         private static string DifferentVersionFilename(string levelIdHash, out List<LevelInfo> levels, out int idx)
         {
             levels = GetMPLevels();
@@ -75,7 +85,11 @@ namespace GameMod {
         }
 
         private static PropertyInfo _LevelInfo_LevelNum_property = typeof(LevelInfo).GetProperty("LevelNum", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        // return false if failed
+        /// <summary>
+        /// Disables any active level matching the filename of the given level ID hash.
+        /// </summary>
+        /// <returns>True if the level was disabled, or no matching level was found;
+        /// false if the operation failed.</returns>
         private static bool DisableDifferentVersion(string levelIdHash, Action<string, bool> log)
         {
             string fn = DifferentVersionFilename(levelIdHash, out List<LevelInfo> levels, out int idx);
@@ -140,6 +154,10 @@ namespace GameMod {
             return false;
         }
 
+        /// <summary>
+        /// Returns the path to a disabled .zip file that contains the specified level (whose version must match),
+        /// or null if none exists.
+        /// </summary>
         private static string FindDisabledLevel(string levelIdHash)
         {
             foreach (var dir in new [] { DataLevelDir, DLCLevelDir })

--- a/GameMod/MPDownloadLevel.cs
+++ b/GameMod/MPDownloadLevel.cs
@@ -159,6 +159,7 @@ namespace GameMod {
                 _getLevelDirectories = () => new[] { DataLevelDir, DLCLevelDir },
                 _showStatusMessage = ShowStatus,
                 _logError = OnLogError,
+                _logDebug = Debug.Log,
                 _downloadFailed = OnDownloadFailed,
                 _serverDownloadCompleted = OnServerDownloadCompleted
             };

--- a/GameMod/MPDownloadLevel.cs
+++ b/GameMod/MPDownloadLevel.cs
@@ -163,9 +163,12 @@ namespace GameMod
         }
 
         private static FieldInfo _NetworkMatch_m_match_force_playlist_level_idx_Field = typeof(NetworkMatch).GetField("m_match_force_playlist_level_idx", BindingFlags.NonPublic | BindingFlags.Static);
-        private static void OnServerDownloadCompleted(int newLevelIndex)
+        private static void OnDownloadCompleted(int newLevelIndex)
         {
-            _NetworkMatch_m_match_force_playlist_level_idx_Field.SetValue(null, newLevelIndex);
+            if (Overload.NetworkManager.IsServer())
+            {
+                _NetworkMatch_m_match_force_playlist_level_idx_Field.SetValue(null, newLevelIndex);
+            }
             DownloadBusy = false;
         }
 
@@ -193,8 +196,8 @@ namespace GameMod
             public override void LogError(string errorMessage, bool showInStatus, float flash = 1) =>
                 OnLogError(errorMessage, showInStatus, flash);
             public override void RemoveMPLevel(int index) => MPDownloadLevel.RemoveMPLevel(index);
-            public override void ServerDownloadCompleted(int newLevelIndex) =>
-                OnServerDownloadCompleted(newLevelIndex);
+            public override void DownloadCompleted(int newLevelIndex) =>
+                OnDownloadCompleted(newLevelIndex);
             public override void ShowStatusMessage(string message, bool forceId) => ShowStatus(message, forceId);
             public override bool ZipContainsLevel(string zipPath, string levelIdHash) =>
                 MPDownloadLevel.ZipContainsLevel(zipPath, levelIdHash);

--- a/GameMod/MPDownloadLevelAlgorithm.cs
+++ b/GameMod/MPDownloadLevelAlgorithm.cs
@@ -1,0 +1,366 @@
+﻿using Newtonsoft.Json.Linq;
+using Overload;
+using Path = System.IO.Path;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace GameMod
+{
+    public class MPDownloadLevelAlgorithm
+    {
+        private const string MapHiddenMarker = "_OCT_Hidden";
+        private static Regex MapHiddenMarkerRE = new Regex(MapHiddenMarker + "[0-9]*$");
+
+        internal Func<List<LevelInfo>> _getMPLevels;
+        internal Action<int> _removeMPLevel;
+        internal Action<string> _addMPLevel;
+        internal Func<string, bool> _canCreateFile;
+        internal Func<string, bool> _fileExists = System.IO.File.Exists;
+        internal Action<string, string> _moveFile = System.IO.File.Move;
+        internal Action<string> _deleteFile = System.IO.File.Delete;
+        internal Func<string, string, bool> _zipContainsLevel;
+        internal Func<string[]> _getLevelDirectories;
+        internal Func<string, bool> _directoryExists = System.IO.Directory.Exists;
+        internal Func<string, string, string[]> _getDirectoryFiles = System.IO.Directory.GetFiles;
+        internal Func<string, System.IO.DirectoryInfo> _createDirectory = System.IO.Directory.CreateDirectory;
+        internal Action<string, bool> _showStatusMessage;
+        internal delegate void LogErrorHandler(string errorMessage, bool showInStatus, float flash = 1f);
+        internal LogErrorHandler _logError;
+        internal Action _downloadFailed;
+        internal delegate void ServerDownloadCompletedHandler(int newLevelIndex);
+        internal ServerDownloadCompletedHandler _serverDownloadCompleted;
+
+        public IEnumerator DoGetLevel(string levelIdHash)
+        {
+            Debug.Log("DoGetLevel " + levelIdHash);
+
+            bool downloadRequired = true;
+            if (FindDisabledLevel(levelIdHash) != null)
+            {
+                try
+                {
+                    if (EnableLevel(levelIdHash))
+                    {
+                        downloadRequired = false;
+                    }
+                }
+                catch (Exception)
+                {
+                    _downloadFailed();
+                    yield break;
+                }
+            }
+            
+            if (downloadRequired)
+            {
+                foreach (var x in LookupAndDownloadLevel(levelIdHash))
+                {
+                    yield return null;
+                }
+            }
+
+            if (Overload.NetworkManager.IsServer())
+            {
+                int idx = GameManager.MultiplayerMission.FindAddOnLevelNumByIdStringHash(levelIdHash);
+                if (idx < 0)
+                {
+                    _downloadFailed(); // if we don't have the level the last message was the error message
+                }
+                else
+                {
+                    _serverDownloadCompleted(idx);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the path to a disabled .zip file that contains the specified level (whose version must match),
+        /// or null if none exists.
+        /// </summary>
+        private string FindDisabledLevel(string levelIdHash)
+        {
+            foreach (var dir in _getLevelDirectories())
+                try
+                {
+                    if (_directoryExists(dir))
+                        foreach (var zipFilename in _getDirectoryFiles(dir, "*.zip" + MapHiddenMarker + "*"))
+                            if (MapHiddenMarkerRE.IsMatch(zipFilename) && _zipContainsLevel(zipFilename, levelIdHash))
+                                return zipFilename;
+                }
+                catch (Exception ex)
+                {
+                    Debug.Log("FindDisabledLevel: reading " + dir + ": " + ex);
+                }
+            return null;
+        }
+
+        /// <summary>
+        /// Attempts to enable a level with the specified hash.
+        /// Returns true if successful, false otherwise. Throws exceptions on fatal errors.
+        /// </summary>
+        private bool EnableLevel(string levelIdHash)
+        {
+            string disabledFilename = FindDisabledLevel(levelIdHash);
+            if (disabledFilename == null)
+            {
+                return false;
+            }
+
+            DisableDifferentVersion(levelIdHash);
+
+            string originalFilename = MapHiddenMarkerRE.Replace(disabledFilename, "");
+            try
+            {
+                _moveFile(disabledFilename, originalFilename);
+            }
+            catch (Exception ex)
+            {
+                _showStatusMessage("ENABLING " + Path.GetFileName(originalFilename) + " FAILED, " + ex.Message, false);
+                return false; // try download
+            }
+            _addMPLevel(originalFilename);
+
+            if (FindLevelIndex(_getMPLevels(), levelIdHash) < 0)
+            {
+                // not possible? would be bug in FindDisabledLevel
+                _logError("ENABLING " + Path.GetFileName(originalFilename) + " FAILED, LEVEL NOT IN FILE", true);
+                throw new Exception();
+            }
+
+            _showStatusMessage("ENABLING " + Path.GetFileName(originalFilename) + " SUCCEEDED", false);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the path of a loaded multiplayer level that matches the filename from the given level ID hash,
+        /// regardless of whether the version matches. Also returns the position of the matching level within the
+        /// loaded multiplayer level list.
+        /// Returns null if no matching level is loaded.
+        /// </summary>
+        private string DifferentVersionFilename(string levelIdHash, out int idx)
+        {
+            List<LevelInfo> levels = _getMPLevels();
+            idx = FindLevelIndex(levels, levelIdHash);
+            if (idx < 0)
+                return null;
+            LevelInfo level = levels[idx];
+            return level.ZipPath ?? level.FilePath;
+        }
+
+        /// <summary>
+        /// Disables any active level matching the filename of the given level ID hash.
+        /// </summary>
+        private void DisableDifferentVersion(string levelIdHash)
+        {
+            string fn = DifferentVersionFilename(levelIdHash, out int idx);
+            if (fn == null)
+                return;
+            try
+            {
+                for (var i = 0; ; i++)
+                {
+                    string dest = fn + MapHiddenMarker + (i == 0 ? "" : i.ToString());
+                    if (!_fileExists(dest))
+                    {
+                        _moveFile(fn, dest);
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.Log(ex);
+                _logError("CANNOT DISABLE OTHER VERSION " + Path.GetFileName(fn), true);
+                throw ex;
+            }
+            _removeMPLevel(idx);
+            _showStatusMessage("OTHER VERSION " + Path.GetFileName(fn) + " DISABLED", false);
+        }
+
+        /// <summary>
+        /// Finds the index of a given level in the provided level list. Checks level file name and
+        /// display name; does not guarantee matching contents.
+        /// Same algorithm as Mission.AddAddOnLevel
+        /// </summary>
+        private static int FindLevelIndex(List<LevelInfo> levels, string levelIdHash)
+        {
+            string fileNameExt = levelIdHash.Split(new[] { ':' })[0];
+            string fileName = Path.GetFileNameWithoutExtension(fileNameExt);
+            string displayName = fileName.Replace('_', ' ').ToUpper();
+            for (int i = 0, count = levels.Count; i < count; i++)
+            {
+                var level = levels[i];
+                if (level.FileName == fileName || level.DisplayName == displayName)
+                    return i;
+            }
+            return -1;
+        }
+
+        private IEnumerable LookupAndDownloadLevel(string levelIdHash)
+        {
+            string url = null;
+            foreach (var x in GetLevelDownloadUrl(levelIdHash))
+            {
+                url = x;
+                yield return null;
+            }
+            if (url == null)
+            {
+                yield break;
+            }
+            string displayName = url.Substring(url.LastIndexOf('/') + 1);
+
+            string fileName = GetLocalDownloadPath(url, levelIdHash);
+            if (fileName == null)
+            {
+                // Failed to find a usable local path
+                yield break;
+            }
+            else if (_zipContainsLevel(fileName, levelIdHash))
+            {
+                // The correct version of the level is already there. Don't need to download, but do need to enable it
+            }
+            else
+            {
+                try
+                {
+                    DisableDifferentVersion(levelIdHash);
+                }
+                catch (Exception)
+                {
+                    yield break;
+                }
+
+                _showStatusMessage("DOWNLOADING " + displayName, true);
+                foreach (var x in DownloadLevel(url, fileName))
+                {
+                    yield return null;
+                }
+            }
+
+            // Now enable the level and ensure it's available
+            _addMPLevel(fileName);
+            if (FindLevelIndex(_getMPLevels(), levelIdHash) < 0)
+            {
+                _logError("DOWNLOADING " + displayName + " FAILED, LEVEL NOT IN FILE", true);
+            }
+            else
+            {
+                _showStatusMessage("DOWNLOADING " + displayName + " COMPLETED", true);
+            }
+        }
+
+        /// <summary>
+        /// Queries overloadmaps.com for a level download URL matching the specified hash.
+        /// The final return value will contain the URL (which may be null if the query failed).
+        /// </summary>
+        private IEnumerable<string> GetLevelDownloadUrl(string levelIdHash)
+        {
+            var li = levelIdHash.IndexOf(".MP");
+            _showStatusMessage("SEARCHING " + levelIdHash.Substring(0, li), true);
+
+            string lastData = null;
+            foreach (var x in NetworkMatch.Get("mpget", new Dictionary<string, string> { { "level", levelIdHash } }, "https://www.overloadmaps.com/api/"))
+            {
+                lastData = x;
+                yield return null;
+            }
+
+            JObject result = null;
+            try
+            {
+                result = JObject.Parse(lastData);
+            }
+            catch (Exception ex)
+            {
+                Debug.Log(ex);
+            }
+            if (result == null)
+            {
+                _logError("OVERLOADMAPS.COM LOOKUP FAILED", true, 2f);
+                yield break;
+            }
+
+            if (!result.TryGetValue("url", out JToken urlVal))
+            {
+                _logError("LEVEL NOT FOUND ON OVERLOADMAPS.COM", true, 2f);
+                yield break;
+            }
+            yield return urlVal.GetString();
+        }
+
+        private string GetLocalDownloadPath(string url, string levelIdHash)
+        {
+            var i = url.LastIndexOf('/');
+            var basefn = url.Substring(i + 1);
+            foreach (var dir in _getLevelDirectories())
+            {
+                try { _createDirectory(dir); } catch (Exception) { }
+                var tryfn = Path.Combine(dir, basefn);
+                if (_fileExists(tryfn))
+                {
+                    if (_zipContainsLevel(tryfn, levelIdHash))
+                    {
+                        return tryfn;
+                    }
+                    string curVersionFile = DifferentVersionFilename(levelIdHash, out int idx);
+                    if (tryfn != curVersionFile)
+                    {
+                        Debug.Log("Download: " + basefn + " already exists, current file: " + curVersionFile);
+                        _logError("DOWNLOAD FAILED: " + basefn + " ALREADY EXISTS", true);
+                        return null;
+                    }
+                }
+                if (_canCreateFile(tryfn + ".tmp"))
+                {
+                    return tryfn;
+                }
+            }
+
+            _logError("DOWNLOAD FAILED: NO WRITABLE DIRECTORY", true);
+            return null;
+        }
+
+        private IEnumerable DownloadLevel(string url, string fn)
+        {
+            Debug.Log("Downloading " + url + " to " + fn);
+            var basefn = Path.GetFileName(fn);
+            var fntmp = fn + ".tmp";
+            using (UnityWebRequest www = new UnityWebRequest(url, "GET"))
+            {
+                www.downloadHandler = new DownloadHandlerFile(fntmp);
+                var request = www.SendWebRequest();
+                while (!request.isDone)
+                {
+                    _showStatusMessage("DOWNLOADING " + basefn + " ... " + Math.Round(request.progress * 100) + "%", true);
+                    yield return null;
+                }
+                if (www.isNetworkError || www.isHttpError)
+                {
+                    _deleteFile(fntmp);
+                    _showStatusMessage("DOWNLOADING " + basefn + " FAILED, " + (www.isNetworkError ? "NETWORK ERROR" : "SERVER ERROR"), true);
+                    yield break;
+                }
+            }
+            _showStatusMessage("DOWNLOADING " + basefn + " ... INSTALLING", true);
+            string msg = null;
+            try
+            {
+                _moveFile(fntmp, fn);
+            }
+            catch (Exception ex)
+            {
+                Debug.Log(ex);
+                msg = ex.Message;
+            }
+            if (msg != null)
+            {
+                _showStatusMessage("DOWNLOADING " + basefn + " FAILED, " + msg, true);
+            }
+        }
+    }
+}

--- a/GameMod/MPDownloadLevelAlgorithm.cs
+++ b/GameMod/MPDownloadLevelAlgorithm.cs
@@ -33,7 +33,7 @@ namespace GameMod
         public abstract void LogDebug(object message);
         public abstract bool IsServer { get; }
         public abstract void DownloadFailed();
-        public abstract void ServerDownloadCompleted(int newLevelIndex);
+        public abstract void DownloadCompleted(int newLevelIndex);
 
         /// <summary>
         /// Queries overloadmaps.com for a level download URL matching the specified hash.
@@ -167,9 +167,9 @@ namespace GameMod
             {
                 _callbacks.DownloadFailed(); // if we don't have the level the last message was the error message
             }
-            else if (_callbacks.IsServer)
+            else
             {
-                _callbacks.ServerDownloadCompleted(idx);
+                _callbacks.DownloadCompleted(idx);
             }
         }
 

--- a/OLModUnitTest/DownloadLevelUnitTest.cs
+++ b/OLModUnitTest/DownloadLevelUnitTest.cs
@@ -1,0 +1,23 @@
+﻿using GameMod;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace OLModUnitTest
+{
+    [TestClass]
+    public class DownloadLevelUnitTest
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+            bool downloadComplete = false;
+            var algorithm = new MPDownloadLevelAlgorithm
+            {
+                _downloadFailed = () => downloadComplete = true
+            };
+            var iterator = algorithm.DoGetLevel("testlevel.mp");
+            while (iterator.MoveNext()) ;
+            Assert.IsTrue(downloadComplete);
+        }
+    }
+}

--- a/OLModUnitTest/DownloadLevelUnitTest.cs
+++ b/OLModUnitTest/DownloadLevelUnitTest.cs
@@ -1,6 +1,10 @@
 ﻿using GameMod;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace OLModUnitTest
 {
@@ -8,16 +12,319 @@ namespace OLModUnitTest
     public class DownloadLevelUnitTest
     {
         [TestMethod]
-        public void TestMethod1()
+        public void TestBasicClientDownload()
         {
+            (var fileSystem, var gameList, var algorithm) = CreateDefaultAlgorithm();
             bool downloadComplete = false;
-            var algorithm = new MPDownloadLevelAlgorithm
-            {
-                _downloadFailed = () => downloadComplete = true
-            };
-            var iterator = algorithm.DoGetLevel("testlevel.mp");
+            algorithm._addMPLevel = (filename) => downloadComplete = true;
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP");
             while (iterator.MoveNext()) ;
             Assert.IsTrue(downloadComplete);
+        }
+
+        [TestMethod]
+        public void TestBasicServerDownload()
+        {
+            (var fileSystem, var gameList, var algorithm) = CreateDefaultAlgorithm();
+            bool downloadComplete = false;
+            algorithm._isServer = () => true;
+            algorithm._serverDownloadCompleted = (newIndex) => downloadComplete = true;
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP");
+            while (iterator.MoveNext()) ;
+            Assert.IsTrue(downloadComplete);
+        }
+
+        private (FakeFileSystem fileSystem, FakeGameList gameList, MPDownloadLevelAlgorithm algorithm) CreateDefaultAlgorithm()
+        {
+            var fileSystem = new FakeFileSystem(@"C:\ProgramData\Revival\Overload", @"E:\steamapps\common\Overload\DLC");
+            var gameList = new FakeGameList(fileSystem);
+            var algorithm = new MPDownloadLevelAlgorithm
+            {
+                _getLevelDownloadUrl = (levelId) => new List<string> {
+                    $"https://overloadmaps.com/files/{Guid.NewGuid():N}/{Path.GetFileNameWithoutExtension(levelId)}.zip"
+                },
+                _downloadLevel = (url, filename) =>
+                {
+                    var file = fileSystem.CreateFile(filename);
+                    file.Levels.Add(Path.GetFileNameWithoutExtension(filename) + ".MP");
+                    return new List<string> { null };
+                },
+                _getMPLevels = () => gameList.GetMPLevels(),
+                _addMPLevel = (filename) => gameList.AddMPLevel(filename),
+                _removeMPLevel = (index) => gameList.RemoveMPLevel(index),
+                _getAddOnLevelIndex = (levelId) => gameList.GetAddOnLevelIndex(levelId),
+                _showStatusMessage = (m, forceId) => { },
+                _logError = (e, show, flash) => { },
+                _logDebug = (m) => { },
+                _isServer = () => false,
+                _downloadFailed = () => { },
+                _serverDownloadCompleted = (newIndex) => { },
+                _canCreateFile = fileSystem.CanCreateFile,
+                _fileExists = fileSystem.FileExists,
+                _moveFile = fileSystem.MoveFile,
+                _deleteFile = fileSystem.DeleteFile,
+                _zipContainsLevel = fileSystem.ZipContainsLevel,
+                _getLevelDirectories = fileSystem.GetLevelDirectories,
+                _directoryExists = fileSystem.DirectoryExists,
+                _getDirectoryFiles = fileSystem.GetDirectoryFiles,
+                _createDirectory = fileSystem.CreateDirectory
+            };
+            return (fileSystem, gameList, algorithm);
+        }
+    }
+
+    internal class FakeFileSystem
+    {
+        private Dictionary<string, FakeDirectory> _directories;
+
+        public FakeFileSystem(params string[] baseDirectories)
+        {
+            _directories = new Dictionary<string, FakeDirectory>();
+            foreach (var baseDirectory in baseDirectories)
+            {
+                _directories[baseDirectory] = new FakeDirectory();
+            }
+        }
+
+        internal bool CanCreateFile(string filename)
+        {
+            var directoryName = Path.GetDirectoryName(filename);
+            return DirectoryExists(directoryName) && !GetDirectory(directoryName).Locked;
+        }
+
+        internal bool FileExists(string filename)
+        {
+            var directory = GetDirectory(Path.GetDirectoryName(filename));
+            return directory != null && directory.Files.ContainsKey(Path.GetFileName(filename));
+        }
+
+        internal void MoveFile(string filePath, string newFilePath)
+        {
+            var fromDirectory = GetDirectory(Path.GetDirectoryName(filePath));
+            var toDirectory = GetDirectory(Path.GetDirectoryName(newFilePath));
+            var fromFilename = Path.GetFileName(filePath);
+            var toFilename = Path.GetFileName(newFilePath);
+            if (fromDirectory == null || !fromDirectory.Files.ContainsKey(fromFilename) || toDirectory == null)
+            {
+                throw new FileNotFoundException();
+            }
+            if (fromDirectory.Locked || toDirectory.Locked)
+            {
+                throw new UnauthorizedAccessException();
+            }
+            var file = fromDirectory.Files[fromFilename];
+            fromDirectory.Files.Remove(fromFilename);
+            toDirectory.Files.Add(toFilename, file);
+        }
+
+        internal FakeFile CreateFile(string filePath)
+        {
+            var directory = GetDirectory(Path.GetDirectoryName(filePath));
+            var filename = Path.GetFileName(filePath);
+            if (directory == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+            if (directory.Locked)
+            {
+                throw new UnauthorizedAccessException();
+            }
+            directory.Files.Add(filename, new FakeFile { Filename = filename });
+            return directory.Files[filename];
+        }
+
+        internal void DeleteFile(string filePath)
+        {
+            var directory = GetDirectory(Path.GetDirectoryName(filePath));
+            var filename = Path.GetFileName(filePath);
+            if (directory == null || !directory.Files.ContainsKey(filename))
+            {
+                throw new FileNotFoundException();
+            }
+            if (directory.Locked || directory.Files[filename].Locked)
+            {
+                throw new UnauthorizedAccessException();
+            }
+            directory.Files.Remove(filename);
+        }
+
+        internal bool ZipContainsLevel(string zipFilename, string levelIdHash)
+        {
+            var directory = GetDirectory(Path.GetDirectoryName(zipFilename));
+            var filename = Path.GetFileName(zipFilename);
+            if (directory == null || !directory.Files.ContainsKey(filename))
+            {
+                return false;
+            }
+            var file = directory.Files[filename];
+            return file.IsMission && file.Levels.Contains(levelIdHash);
+        }
+
+        internal string[] GetLevelDirectories()
+        {
+            return _directories.Keys.ToArray();
+        }
+
+        internal bool DirectoryExists(string path)
+        {
+            return GetDirectory(path) != null;
+        }
+
+        internal string[] GetDirectoryFiles(string path, string searchPattern)
+        {
+            var directory = GetDirectory(path);
+            if (directory == null)
+            {
+                throw new DirectoryNotFoundException();
+            }
+            var regexSearchPattern = "^" + Regex.Escape(searchPattern).Replace("\\?", ".").Replace("\\*", ".*") + "$";
+            var matches = directory.Files.Keys.Where(filename => Regex.IsMatch(filename, regexSearchPattern));
+            return matches.ToArray();
+        }
+
+        internal DirectoryInfo CreateDirectory(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        private FakeDirectory GetDirectory(string path)
+        {
+            foreach (var directory in _directories)
+            {
+                if (path.Equals(directory.Key, StringComparison.OrdinalIgnoreCase))
+                {
+                    return directory.Value;
+                }
+                else
+                {
+                    var pathWithSeparator = directory.Key.TrimEnd(Path.DirectorySeparatorChar) +
+                        Path.DirectorySeparatorChar;
+                    if (path.StartsWith(pathWithSeparator, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return directory.Value.GetDirectory(path.Substring(pathWithSeparator.Length));
+                    }
+                }
+            }
+            return null;
+        }
+
+        internal FakeFile GetFile(string filePath)
+        {
+            var directory = GetDirectory(Path.GetDirectoryName(filePath));
+            var filename = Path.GetFileName(filePath);
+            if (directory == null || !directory.Files.ContainsKey(filename))
+            {
+                throw new FileNotFoundException();
+            }
+            return directory.Files[filename];
+        }
+
+        private class FakeDirectory
+        {
+            public bool Locked { get; internal set; } = false;
+
+            public Dictionary<string, FakeDirectory> Subdirectories { get; } = new Dictionary<string, FakeDirectory>();
+
+            public Dictionary<string, FakeFile> Files { get; } = new Dictionary<string, FakeFile>();
+
+            public FakeDirectory GetDirectory(string path)
+            {
+                foreach (var subdirectory in Subdirectories)
+                {
+                    if (path.Equals(subdirectory.Key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return subdirectory.Value;
+                    }
+                    else
+                    {
+                        var pathWithSeparator = subdirectory.Key.TrimEnd(Path.DirectorySeparatorChar) +
+                            Path.DirectorySeparatorChar;
+                        if (path.StartsWith(pathWithSeparator, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return subdirectory.Value.GetDirectory(path.Substring(pathWithSeparator.Length));
+                        }
+                    }
+                }
+                return null;
+            }
+        }
+
+        internal class FakeFile
+        {
+            public string Filename { get; set; }
+
+            public bool Locked { get; set; } = false;
+
+            public bool IsMission { get; }
+
+            public List<string> Levels { get; } = new List<string>();
+        }
+    }
+
+    internal class FakeGameList
+    {
+        private readonly List<LevelDownloadInfo> _levels = new List<LevelDownloadInfo>();
+        private readonly FakeFileSystem _fileSystem;
+
+        public FakeGameList(FakeFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        internal IEnumerable<ILevelDownloadInfo> GetMPLevels()
+        {
+            return _levels;
+        }
+
+        internal void AddMPLevel(string filename)
+        {
+            if (filename.EndsWith(".mp", StringComparison.InvariantCultureIgnoreCase))
+            {
+                string filenameInternal = Path.GetFileNameWithoutExtension(filename);
+                string displayName = filenameInternal.Replace('_', ' ').ToUpper();
+                var levelInfo = new LevelDownloadInfo(filenameInternal, displayName, null, filename);
+                _levels.Add(levelInfo);
+            }
+            else if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
+            {
+                FakeFileSystem.FakeFile zip = _fileSystem.GetFile(filename);
+                foreach (string levelFilename in zip.Levels)
+                {
+                    string filenameInternal = Path.GetFileNameWithoutExtension(levelFilename);
+                    string displayName = filenameInternal.Replace('_', ' ').ToUpper();
+                    var levelInfo = new LevelDownloadInfo(filenameInternal, displayName, filename, null);
+                    _levels.Add(levelInfo);
+                }
+            }
+        }
+
+        internal void RemoveMPLevel(int index)
+        {
+            _levels.RemoveAt(index);
+        }
+
+        internal int GetAddOnLevelIndex(string levelId)
+        {
+            return _levels.FindIndex(levelInfo => levelInfo.FileName == Path.GetFileNameWithoutExtension(levelId));
+        }
+
+        private class LevelDownloadInfo : ILevelDownloadInfo
+        {
+            public LevelDownloadInfo(string fileName, string displayName, string zipPath, string filePath)
+            {
+                FileName = fileName;
+                DisplayName = displayName;
+                ZipPath = zipPath;
+                FilePath = filePath;
+            }
+
+            public string FileName { get; }
+
+            public string DisplayName { get; }
+
+            public string ZipPath { get; }
+
+            public string FilePath { get; }
         }
     }
 }

--- a/OLModUnitTest/DownloadLevelUnitTest.cs
+++ b/OLModUnitTest/DownloadLevelUnitTest.cs
@@ -23,6 +23,7 @@ namespace OLModUnitTest
             while (iterator.MoveNext()) ;
 
             callbacks.Verify(c => c.AddMPLevel(@"C:\ProgramData\Revival\Overload\testlevel.zip"));
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestMethod]
@@ -32,12 +33,12 @@ namespace OLModUnitTest
             serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
 
             callbacks.SetupGet(c => c.IsServer).Returns(true);
-            callbacks.Setup(c => c.ServerDownloadCompleted(It.IsAny<int>()));
+            callbacks.Setup(c => c.DownloadCompleted(It.IsAny<int>()));
 
             var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
             while (iterator.MoveNext()) ;
 
-            callbacks.Verify(c => c.ServerDownloadCompleted(It.IsAny<int>()));
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("EnableLevel")]
@@ -59,6 +60,9 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()));
             // We expect the file to have been renamed too
             Assert.AreEqual("testlevel.zip", file.Filename);
+            // DownloadCompleted should be signalled (note this means the "download attempt" succeeded,
+            // not necessarily that anything actually had to be downloaded)
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("EnableLevel")]
@@ -75,6 +79,7 @@ namespace OLModUnitTest
 
             callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()));
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
             Assert.AreEqual("TESTLEVEL.ZIP", file.Filename);
         }
 
@@ -92,6 +97,7 @@ namespace OLModUnitTest
 
             callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()));
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
             Assert.AreEqual("testlevel2.zip", file.Filename);
         }
 
@@ -184,6 +190,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         [TestCategory("EnableLevel")]
@@ -212,6 +219,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.RemoveMPLevel(0));
             // The algorithm should add the new level
             callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            callbacks.Verify(c => c.DownloadCompleted(0));
             // The old level should be renamed
             Assert.AreEqual("testlevel.zip_OCT_Hidden1", currentFile.Filename);
         }
@@ -262,6 +270,7 @@ namespace OLModUnitTest
             // The algorithm should add the new level
             string expectedFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
             callbacks.Verify(c => c.AddMPLevel(expectedFilePath));
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
             // The existing files should not have been renamed
             Assert.AreEqual("otherlevel.zip", otherFile.Filename);
             Assert.AreEqual("otherlevel2.zip", otherFile2.Filename);
@@ -282,6 +291,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -311,6 +321,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -336,6 +347,7 @@ namespace OLModUnitTest
             Assert.AreEqual(0, firstDirectory.Files.Count);
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -359,6 +371,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.AddMPLevel(filePath));
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -387,6 +400,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.RemoveMPLevel(0));
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -415,6 +429,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.RemoveMPLevel(0));
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -442,6 +457,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.RemoveMPLevel(It.IsAny<int>()), Times.Never);
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -471,6 +487,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.RemoveMPLevel(0));
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -501,6 +518,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.RemoveMPLevel(It.IsAny<int>()), Times.Exactly(2));
             // The download should not be reported as failed
             callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()));
         }
 
         [TestCategory("GetLocalDownloadPath")]
@@ -524,6 +542,7 @@ namespace OLModUnitTest
             callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         [TestMethod]
@@ -548,6 +567,7 @@ namespace OLModUnitTest
             }
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         [TestMethod]
@@ -572,6 +592,7 @@ namespace OLModUnitTest
             Assert.AreEqual(-1, gameList.GetAddOnLevelIndex("TESTLEVEL.MP:AF5E61F2"));
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         [TestMethod]
@@ -591,7 +612,7 @@ namespace OLModUnitTest
             // The download should be reported as failed
             callbacks.Verify(c => c.DownloadFailed());
             // The download should NOT be reported as completed
-            callbacks.Verify(c => c.ServerDownloadCompleted(It.IsAny<int>()), Times.Never);
+            callbacks.Verify(c => c.DownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
         private (FakeFileSystem fileSystem, FakeGameList gameList,

--- a/OLModUnitTest/DownloadLevelUnitTest.cs
+++ b/OLModUnitTest/DownloadLevelUnitTest.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -15,20 +16,27 @@ namespace OLModUnitTest
         [TestMethod]
         public void TestBasicClientDownload()
         {
-            (var fileSystem, var gameList, var callbacks, var algorithm) = CreateDefaultAlgorithm();
-            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP");
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
             while (iterator.MoveNext()) ;
+
             callbacks.Verify(c => c.AddMPLevel(@"C:\ProgramData\Revival\Overload\testlevel.zip"));
         }
 
         [TestMethod]
         public void TestBasicServerDownload()
         {
-            (var fileSystem, var gameList, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
             callbacks.SetupGet(c => c.IsServer).Returns(true);
             callbacks.Setup(c => c.ServerDownloadCompleted(It.IsAny<int>()));
-            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP");
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
             while (iterator.MoveNext()) ;
+
             callbacks.Verify(c => c.ServerDownloadCompleted(It.IsAny<int>()));
         }
 
@@ -36,17 +44,13 @@ namespace OLModUnitTest
         [TestMethod]
         public void TestEnableLevel()
         {
-            (var fileSystem, var gameList, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
 
-            // Create a simulated level already on disk but not in the game list
+            // Create a simulated level already on disk but disabled and not in the game list
             var file = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden");
-            file.IsMission = true;
-            file.Levels.Add("testlevel.mp");
+            file.Levels.Add("testlevel.mp", 0xAF5E61F2);
 
-            callbacks.Setup(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
-            callbacks.Setup(c => c.AddMPLevel(It.IsAny<string>()));
-
-            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP");
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
             while (iterator.MoveNext()) ;
 
             // The algorithm should not download the level
@@ -61,142 +65,571 @@ namespace OLModUnitTest
         [TestMethod]
         public void TestEnableLevel_UpperCase()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+
+            var file = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\TESTLEVEL.ZIP_OCT_Hidden");
+            file.Levels.Add("TESTLEVEL.MP", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()));
+            Assert.AreEqual("TESTLEVEL.ZIP", file.Filename);
+        }
+
+        [TestCategory("EnableLevel")]
+        [TestMethod]
+        public void TestEnableLevel_DifferentFileName()
+        {
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+
+            var file = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel2.zip_OCT_Hidden");
+            file.Levels.Add("testlevel.mp", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()));
+            Assert.AreEqual("testlevel2.zip", file.Filename);
         }
 
         [TestCategory("EnableLevel")]
         [TestMethod]
         public void TestEnableLevel_DifferentVersionDisabled()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+
+            // Create a simulated level currently in the game list
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(originalFilePath);
+            // And a simulated level on disk but not in the game list
+            var newFile = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden");
+            newFile.Levels.Add("testlevel.mp", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should not download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // The algorithm should remove the old level
+            callbacks.Verify(c => c.RemoveMPLevel(0));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            // Both files should have been renamed
+            Assert.AreEqual("testlevel.zip_OCT_Hidden1", currentFile.Filename);
+            Assert.AreEqual("testlevel.zip", newFile.Filename);
         }
 
         [TestCategory("EnableLevel")]
         [TestMethod]
         public void TestEnableLevel_MultipleDifferentVersions()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // Level #1 (current)
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(originalFilePath);
+            // Level #2 (disabled, no match)
+            var otherFile = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden");
+            otherFile.Levels.Add("testlevel.mp", 0x7EF7033A);
+            // Level #3 (disabled, match)
+            var newFile = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden2");
+            newFile.Levels.Add("testlevel.mp", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should not download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // The algorithm should remove the old level
+            callbacks.Verify(c => c.RemoveMPLevel(0));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            // Both files should have been renamed; other level should not
+            Assert.AreEqual("testlevel.zip_OCT_Hidden1", currentFile.Filename);
+            Assert.AreEqual("testlevel.zip_OCT_Hidden", otherFile.Filename);
+            Assert.AreEqual("testlevel.zip", newFile.Filename);
         }
 
         [TestCategory("EnableLevel")]
         [TestMethod]
         public void TestEnableLevel_DifferentVersionDisableFails_Abort()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // Currently loaded level is not writeable
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Locked = true;
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(originalFilePath);
+
+            var newFile = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden");
+            newFile.Levels.Add("testlevel.mp", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should not download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // The algorithm should not remove the old level
+            callbacks.Verify(c => c.RemoveMPLevel(It.IsAny<int>()), Times.Never);
+            // The algorithm should not add the new level
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
         }
 
         [TestCategory("EnableLevel")]
         [TestMethod]
         public void TestEnableLevelFails_Download()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // Currently loaded level
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(originalFilePath);
+            // Disabled level (not writeable)
+            var newFile = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden");
+            newFile.Locked = true;
+            newFile.Levels.Add("testlevel.mp", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should remove the old level
+            callbacks.Verify(c => c.RemoveMPLevel(0));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            // The old level should be renamed
+            Assert.AreEqual("testlevel.zip_OCT_Hidden1", currentFile.Filename);
         }
 
         [TestCategory("EnableLevel")]
         [TestMethod]
         public void TestFindDisabledLevel_LevelNotPresent_Skip()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Create a zip archive that does not contain the level
+            var file = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip_OCT_Hidden");
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()));
+            // The existing file should not have been renamed
+            Assert.AreEqual("testlevel.zip_OCT_Hidden", file.Filename);
         }
 
         [TestCategory("EnableLevel")]
         [TestMethod]
         public void TestFindDisabledLevel_LevelNotDisabled_Skip()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Existing file #1: does not contain the correct level, loaded
+            string otherFilePath = fileSystem.GetLevelDirectories()[0] + "\\otherlevel.zip";
+            var otherFile = fileSystem.CreateFile(otherFilePath);
+            otherFile.Levels.Add("otherlevel.mp", 0xCA98CF04);
+            gameList.AddMPLevel(otherFilePath);
+
+            // Existing file #2: does not contain the correct level, not loaded
+            var otherFile2 = fileSystem.CreateFile(fileSystem.GetLevelDirectories()[0] + "\\otherlevel2.zip");
+            otherFile2.Levels.Add("otherlevel2.mp", 0x92E41697);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the new level
+            string expectedFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            callbacks.Verify(c => c.AddMPLevel(expectedFilePath));
+            // The existing files should not have been renamed
+            Assert.AreEqual("otherlevel.zip", otherFile.Filename);
+            Assert.AreEqual("otherlevel2.zip", otherFile2.Filename);
         }
 
         [TestMethod]
         public void TestDownloadLevel_UrlNotFound_Abort()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            // This time the server does not have the level
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should not try to download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // The algorithm should not add a level
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_CreateDirectory()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Override DirectoryExists to report that the first directory does not exist
+            var firstDirectoryPath = fileSystem.GetLevelDirectories()[0];
+            callbacks.Setup(c => c.DirectoryExists(It.IsAny<string>())).Returns((string path) =>
+            {
+                if (path == firstDirectoryPath)
+                {
+                    return false;
+                }
+                return fileSystem.DirectoryExists(path);
+            });
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should try to create the directory
+            callbacks.Verify(c => c.CreateDirectory(firstDirectoryPath));
+            // The algorithm should download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_CannotWriteFirstDirectory_UseSecondDirectory()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Lock the first directory so it can't be written
+            var firstDirectory = fileSystem.GetDirectory(fileSystem.GetLevelDirectories()[0]);
+            firstDirectory.Locked = true;
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the level to the second directory
+            string expectedFilePath = fileSystem.GetLevelDirectories()[1] + "\\testlevel.zip";
+            callbacks.Verify(c => c.AddMPLevel(expectedFilePath));
+            // There should be no files in the first directory
+            Assert.AreEqual(0, firstDirectory.Files.Count);
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_FileExistsLevelPresent_AddLevel()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // The level is already on disk, with the right CRC, but not loaded
+            string filePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            var file = fileSystem.CreateFile(filePath);
+            file.Levels.Add("testlevel.mp", 0xAF5E61F2);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should not download the level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // The algorithm should add the existing level
+            callbacks.Verify(c => c.AddMPLevel(filePath));
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_FileExistsDifferentVersionPresent_DisableExistingLevel()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // The level is already on disk, but with the wrong CRC
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(originalFilePath);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the new level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            // The existing file should have been renamed
+            Assert.AreEqual("testlevel.zip_OCT_Hidden", currentFile.Filename);
+            // The existing level should have been unloaded
+            callbacks.Verify(c => c.RemoveMPLevel(0));
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_FileExistsLevelNotPresent_DisableExistingLevel()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // There is a file on disk with the expected name, but without the correct level in it
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Levels.Add("otherlevel.mp", 0xCA98CF04);
+            gameList.AddMPLevel(originalFilePath);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the new level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            // The existing file should have been renamed
+            Assert.AreEqual("testlevel.zip_OCT_Hidden", currentFile.Filename);
+            // The existing level should have been unloaded
+            callbacks.Verify(c => c.RemoveMPLevel(0));
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_FileExistsWriteProtected_Abort()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // A different version of the level is on disk, but is write-protected
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Locked = true;
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(originalFilePath);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should not download the new level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            // The new level should not be added
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
+            // The existing level should not be unloaded
+            callbacks.Verify(c => c.RemoveMPLevel(It.IsAny<int>()), Times.Never);
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
+        }
+
+        [TestCategory("GetLocalDownloadPath")]
+        [TestMethod]
+        public void TestGetLocalDownloadPath_DifferentVersionPresentDifferentFile_DisableExistingLevel()
+        {
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // A different version of the level is already loaded from a different .zip
+            string currentFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel2.zip";
+            var currentFile = fileSystem.CreateFile(currentFilePath);
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            gameList.AddMPLevel(currentFilePath);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the new level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the new level
+            string expectedFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            callbacks.Verify(c => c.AddMPLevel(expectedFilePath));
+            // The existing file should have been renamed
+            Assert.AreEqual("testlevel2.zip_OCT_Hidden", currentFile.Filename);
+            // The existing level should have been unloaded
+            callbacks.Verify(c => c.RemoveMPLevel(0));
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
+        }
+
+        [TestCategory("GetLocalDownloadPath")]
+        [TestMethod]
+        public void TestGetLocalDownloadPath_DisableExistingLevelCollateralDamage()
+        {
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            string originalFilePath = fileSystem.GetLevelDirectories()[0] + "\\testlevel.zip";
+            // The level is already on disk, but with the wrong CRC.
+            // There is also a second level loaded from the same .zip.
+            var currentFile = fileSystem.CreateFile(originalFilePath);
+            currentFile.Levels.Add("testlevel.mp", 0x6DAF487E);
+            currentFile.Levels.Add("otherlevel.mp", 0xCA98CF04);
+            gameList.AddMPLevel(originalFilePath);
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The algorithm should download the new level
+            callbacks.Verify(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()));
+            // The algorithm should add the new level
+            callbacks.Verify(c => c.AddMPLevel(originalFilePath));
+            // The existing file should have been renamed
+            Assert.AreEqual("testlevel.zip_OCT_Hidden", currentFile.Filename);
+            // The existing levels should BOTH have been unloaded
+            callbacks.Verify(c => c.RemoveMPLevel(It.IsAny<int>()), Times.Exactly(2));
+            // The download should not be reported as failed
+            callbacks.Verify(c => c.DownloadFailed(), Times.Never);
         }
 
         [TestCategory("GetLocalDownloadPath")]
         [TestMethod]
         public void TestGetLocalDownloadPath_NoWriteablePath_Abort()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Lock all directories
+            foreach (var directoryPath in fileSystem.GetLevelDirectories())
+            {
+                var directory = fileSystem.GetDirectory(directoryPath);
+                directory.Locked = true;
+            }
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The level should not be added
+            callbacks.Verify(c => c.AddMPLevel(It.IsAny<string>()), Times.Never);
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
         }
 
         [TestMethod]
         public void TestDownloadFails_Abort()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Override DownloadLevel, cause it to do nothing (emulating a download failure)
+            callbacks.Setup(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The level should not be in the game list (it may have tried to add it but this should fail)
+            Assert.AreEqual(0, gameList.GetMPLevels().Count());
+            // There should be no files in any directory
+            foreach (var directoryPath in fileSystem.GetLevelDirectories())
+            {
+                var directory = fileSystem.GetDirectory(directoryPath);
+                Assert.AreEqual(0, directory.Files.Count);
+            }
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
         }
 
         [TestMethod]
         public void TestDownloadBadMission_Abort()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Override DownloadLevel, cause it to download the wrong level
+            callbacks.Setup(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string url, string filename) =>
+                {
+                    var file = fileSystem.CreateFile(filename);
+                    file.Levels.Add("testlevel.mp", 0x6DAF487E);
+                    return new List<string>();
+                });
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The level should not be in the game list (it may have tried to add it but this should fail)
+            Assert.AreEqual(-1, gameList.GetAddOnLevelIndex("TESTLEVEL.MP:AF5E61F2"));
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
         }
 
         [TestMethod]
         public void TestServerDownloadFails_ReportError()
         {
-            Assert.Fail();
+            (var fileSystem, var gameList, var serverFiles, var callbacks, var algorithm) = CreateDefaultAlgorithm();
+            serverFiles.Add(Guid.NewGuid(), new FakeFileSystem.FakeFile { Levels = { { "testlevel.mp", 0xAF5E61F2 } } });
+
+            // Override DownloadLevel, cause it to do nothing (emulating a download failure)
+            callbacks.Setup(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
+
+            var iterator = algorithm.DoGetLevel("TESTLEVEL.MP:AF5E61F2");
+            while (iterator.MoveNext()) ;
+
+            // The level should not be in the game list (it may have tried to add it but this should fail)
+            Assert.AreEqual(-1, gameList.GetAddOnLevelIndex("TESTLEVEL.MP:AF5E61F2"));
+            // The download should be reported as failed
+            callbacks.Verify(c => c.DownloadFailed());
+            // The download should NOT be reported as completed
+            callbacks.Verify(c => c.ServerDownloadCompleted(It.IsAny<int>()), Times.Never);
         }
 
-        private (FakeFileSystem fileSystem, FakeGameList gameList, Mock<DownloadLevelCallbacks> callbacks,
+        private (FakeFileSystem fileSystem, FakeGameList gameList,
+            Dictionary<Guid, FakeFileSystem.FakeFile> serverFiles, Mock<DownloadLevelCallbacks> callbacks,
             MPDownloadLevelAlgorithm algorithm) CreateDefaultAlgorithm()
         {
             var fileSystem = new FakeFileSystem(@"C:\ProgramData\Revival\Overload", @"E:\steamapps\common\Overload\DLC");
             var gameList = new FakeGameList(fileSystem);
+            var serverFiles = new Dictionary<Guid, FakeFileSystem.FakeFile>();
             var callbacks = new Mock<DownloadLevelCallbacks> { CallBase = true };
             var algorithm = new MPDownloadLevelAlgorithm(callbacks.Object);
 
             callbacks.Setup(c => c.GetLevelDownloadUrl(It.IsAny<string>()))
-                .Returns<string>(levelId => new List<string>
+                .Returns<string>(levelIdHash =>
                 {
-                    $"https://overloadmaps.com/files/{Guid.NewGuid():N}/{Path.GetFileNameWithoutExtension(levelId).ToLower()}.zip"
+                    var results = serverFiles.Where(
+                        file => file.Value.Levels.Keys.Contains(levelIdHash.Split(':')[0], StringComparer.OrdinalIgnoreCase));
+                    if (results.Count() == 0)
+                    {
+                        return new List<string>();
+                    }
+                    var guid = results.First().Key;
+                    var zipName = levelIdHash.Split('.', ':')[0].ToLower();
+                    return new List<string> { $"https://overloadmaps.com/files/{guid:N}/{zipName}.zip" };
                 });
             callbacks.Setup(c => c.DownloadLevel(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns((string url, string filename) =>
                 {
-                    var file = fileSystem.CreateFile(filename);
-                    file.Levels.Add(Path.GetFileNameWithoutExtension(filename) + ".MP");
+                    var match = Regex.Match(url, @"^https://overloadmaps\.com/files/([0-9a-fA-F]{32})/\w+\.zip$");
+                    var guid = Guid.Parse(match.Groups[1].Value);
+                    if (serverFiles.ContainsKey(guid))
+                    {
+                        var file = fileSystem.CreateFile(filename);
+                        foreach (var item in serverFiles[guid].Levels)
+                        {
+                            file.Levels.Add(item.Key, item.Value);
+                        }
+                    }
                     return new List<string>();
                 });
             callbacks.Setup(c => c.GetMPLevels()).Returns(gameList.GetMPLevels());
@@ -205,7 +638,7 @@ namespace OLModUnitTest
             callbacks.Setup(c => c.RemoveMPLevel(It.IsAny<int>()))
                 .Callback<int>(index => gameList.RemoveMPLevel(index));
             callbacks.Setup(c => c.GetAddOnLevelIndex(It.IsAny<string>()))
-                .Returns<string>(levelId => gameList.GetAddOnLevelIndex(levelId));
+                .Returns<string>(levelIdHash => gameList.GetAddOnLevelIndex(levelIdHash));
             callbacks.SetupGet(c => c.IsServer).Returns(false);
             callbacks.Setup(c => c.CanCreateFile(It.IsAny<string>()))
                 .Returns((string filename) => fileSystem.CanCreateFile(filename));
@@ -224,9 +657,9 @@ namespace OLModUnitTest
             callbacks.Setup(c => c.GetDirectoryFiles(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns((string path, string searchPattern) => fileSystem.GetDirectoryFiles(path, searchPattern));
             callbacks.Setup(c => c.CreateDirectory(It.IsAny<string>()))
-                .Callback<string>(path => fileSystem.CreateDirectory(path));
+                .Returns((string path) => fileSystem.CreateDirectory(path));
 
-            return (fileSystem, gameList, callbacks, algorithm);
+            return (fileSystem, gameList, serverFiles, callbacks, algorithm);
         }
     }
 
@@ -265,11 +698,11 @@ namespace OLModUnitTest
             {
                 throw new FileNotFoundException();
             }
-            if (fromDirectory.Locked || toDirectory.Locked)
+            var file = fromDirectory.Files[fromFilename];
+            if (fromDirectory.Locked || toDirectory.Locked || file.Locked)
             {
                 throw new UnauthorizedAccessException();
             }
-            var file = fromDirectory.Files[fromFilename];
             fromDirectory.Files.Remove(fromFilename);
             toDirectory.Files.Add(toFilename, file);
             file.Filename = toFilename;
@@ -315,7 +748,13 @@ namespace OLModUnitTest
                 return false;
             }
             var file = directory.Files[filename];
-            return file.IsMission && file.Levels.Contains(levelIdHash, StringComparer.OrdinalIgnoreCase);
+
+            var requestedLevelFilename = levelIdHash.Split(':')[0];
+            var requestedLevelCrc32 = uint.Parse(levelIdHash.Split(':')[1], NumberStyles.HexNumber);
+            var foundLevelFilename = file.Levels.Keys.FirstOrDefault(
+                key => key.Equals(requestedLevelFilename, StringComparison.OrdinalIgnoreCase));
+            return foundLevelFilename != default(string) &&
+                file.Levels[foundLevelFilename] == requestedLevelCrc32;
         }
 
         internal string[] GetLevelDirectories()
@@ -338,17 +777,48 @@ namespace OLModUnitTest
             var pathWithSeparator = path.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
             var regexSearchPattern = "^" + Regex.Escape(searchPattern).Replace("\\?", ".").Replace("\\*", ".*") + "$";
             var matches = from filename in directory.Files.Keys
-                          where Regex.IsMatch(filename, regexSearchPattern)
+                          where Regex.IsMatch(filename, regexSearchPattern, RegexOptions.IgnoreCase)
                           select pathWithSeparator + filename;
             return matches.ToArray();
         }
 
         internal DirectoryInfo CreateDirectory(string path)
         {
-            throw new NotImplementedException();
+            var currentDirectories = _directories;
+            var remainingPath = path.TrimStart(Path.DirectorySeparatorChar);
+
+            // Search until we reach a directory that already exists (no remaining path to find/create)
+            while (remainingPath.Split(Path.DirectorySeparatorChar)[0].Length > 0)
+            {
+                var subdirectoryName = remainingPath.Split(Path.DirectorySeparatorChar)[0];
+                foreach (var directory in currentDirectories)
+                {
+                    if (subdirectoryName.Equals(directory.Key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Found a match, continue looking down this directory
+                        if (directory.Value.Locked)
+                        {
+                            throw new UnauthorizedAccessException();
+                        }
+                        currentDirectories = directory.Value.Subdirectories;
+                        remainingPath = remainingPath.Substring(subdirectoryName.Length)
+                            .TrimStart(Path.DirectorySeparatorChar);
+                        break;
+                    }
+                }
+
+                // No match found, create a directory here
+                currentDirectories[subdirectoryName] = new FakeDirectory();
+                currentDirectories = currentDirectories[subdirectoryName].Subdirectories;
+                remainingPath = remainingPath.Substring(subdirectoryName.Length)
+                    .TrimStart(Path.DirectorySeparatorChar);
+            }
+
+            // Currently the caller doesn't use DirectoryInfo, and it isn't safe to create anyway
+            return null;
         }
 
-        private FakeDirectory GetDirectory(string path)
+        internal FakeDirectory GetDirectory(string path)
         {
             foreach (var directory in _directories)
             {
@@ -380,7 +850,7 @@ namespace OLModUnitTest
             return directory.Files[filename];
         }
 
-        private class FakeDirectory
+        internal class FakeDirectory
         {
             public bool Locked { get; internal set; } = false;
 
@@ -416,9 +886,7 @@ namespace OLModUnitTest
 
             public bool Locked { get; set; } = false;
 
-            public bool IsMission { get; set; }
-
-            public List<string> Levels { get; } = new List<string>();
+            public Dictionary<string, uint> Levels { get; } = new Dictionary<string, uint>();
         }
     }
 
@@ -443,17 +911,26 @@ namespace OLModUnitTest
             {
                 string filenameInternal = Path.GetFileNameWithoutExtension(filename);
                 string displayName = filenameInternal.Replace('_', ' ').ToUpper();
-                var levelInfo = new LevelDownloadInfo(filenameInternal, displayName, null, filename);
+                var levelInfo = new LevelDownloadInfo(filenameInternal, displayName, null, filename, null);
                 _levels.Add(levelInfo);
             }
             else if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
             {
-                FakeFileSystem.FakeFile zip = _fileSystem.GetFile(filename);
-                foreach (string levelFilename in zip.Levels)
+                FakeFileSystem.FakeFile zip;
+                try
                 {
-                    string filenameInternal = Path.GetFileNameWithoutExtension(levelFilename);
+                    zip = _fileSystem.GetFile(filename);
+                }
+                catch (Exception)
+                {
+                    return;
+                }
+                foreach (var level in zip.Levels)
+                {
+                    string filenameInternal = Path.GetFileNameWithoutExtension(level.Key);
                     string displayName = filenameInternal.Replace('_', ' ').ToUpper();
-                    var levelInfo = new LevelDownloadInfo(filenameInternal, displayName, filename, null);
+                    string levelIdHash = string.Format("{0}:{1:X8}", level.Key.ToUpper(), level.Value);
+                    var levelInfo = new LevelDownloadInfo(filenameInternal, displayName, filename, null, levelIdHash);
                     _levels.Add(levelInfo);
                 }
             }
@@ -464,20 +941,21 @@ namespace OLModUnitTest
             _levels.RemoveAt(index);
         }
 
-        internal int GetAddOnLevelIndex(string levelId)
+        internal int GetAddOnLevelIndex(string levelIdHash)
         {
-            return _levels.FindIndex(levelInfo => StringComparer.OrdinalIgnoreCase.Compare(levelInfo.FileName,
-                Path.GetFileNameWithoutExtension(levelId)) == 0);
+            return _levels.FindIndex(levelInfo => levelInfo.IdStringHash == levelIdHash);
         }
 
         private class LevelDownloadInfo : ILevelDownloadInfo
         {
-            public LevelDownloadInfo(string fileName, string displayName, string zipPath, string filePath)
+            public LevelDownloadInfo(string fileName, string displayName, string zipPath, string filePath,
+                string idStringHash)
             {
                 FileName = fileName;
                 DisplayName = displayName;
                 ZipPath = zipPath;
                 FilePath = filePath;
+                IdStringHash = idStringHash;
             }
 
             public string FileName { get; }
@@ -487,6 +965,8 @@ namespace OLModUnitTest
             public string ZipPath { get; }
 
             public string FilePath { get; }
+
+            public string IdStringHash { get; }
         }
     }
 }

--- a/OLModUnitTest/OLModUnitTest.csproj
+++ b/OLModUnitTest/OLModUnitTest.csproj
@@ -39,14 +39,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.4.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.9\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.9\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.17.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.17.2\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DownloadLevelUnitTest.cs" />

--- a/OLModUnitTest/OLModUnitTest.csproj
+++ b/OLModUnitTest/OLModUnitTest.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A3A1AFA7-6214-4624-80F6-B17B60B36916}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OLModUnitTest</RootNamespace>
+    <AssemblyName>OLModUnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DownloadLevelUnitTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GameMod\GameMod.csproj">
+      <Project>{fb32eb50-de78-4ffb-8de8-c3c8a82e8b62}</Project>
+      <Name>GameMod</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/OLModUnitTest/OLModUnitTest.csproj
+++ b/OLModUnitTest/OLModUnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,10 +40,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.9\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.9\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -67,8 +67,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.9\build\net46\MSTest.TestAdapter.targets')" />
 </Project>

--- a/OLModUnitTest/Properties/AssemblyInfo.cs
+++ b/OLModUnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("OLModUnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OLModUnitTest")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("a3a1afa7-6214-4624-80f6-b17b60b36916")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OLModUnitTest/packages.config
+++ b/OLModUnitTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
+</packages>

--- a/OLModUnitTest/packages.config
+++ b/OLModUnitTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
-  <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="2.2.9" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.9" targetFramework="net472" />
 </packages>

--- a/OLModUnitTest/packages.config
+++ b/OLModUnitTest/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.4.1" targetFramework="net472" />
+  <package id="Moq" version="4.17.2" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="2.2.9" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.2.9" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>

--- a/olmod.sln
+++ b/olmod.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32002.185
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.329
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "olmod", "olmod\olmod.vcxproj", "{CFB62AD7-1212-4E0F-A695-1503E89A578F}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/olmod.sln
+++ b/olmod.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "olmod", "olmod\olmod.vcxproj", "{CFB62AD7-1212-4E0F-A695-1503E89A578F}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OLModUnitTest", "OLModUnitTest\OLModUnitTest.csproj", "{A3A1AFA7-6214-4624-80F6-B17B60B36916}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +52,14 @@ Global
 		{5F11C292-D523-4C7F-88FA-3414F62A001A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5F11C292-D523-4C7F-88FA-3414F62A001A}.Release|x64.ActiveCfg = Release|Any CPU
 		{5F11C292-D523-4C7F-88FA-3414F62A001A}.Release|x64.Build.0 = Release|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Debug|x64.Build.0 = Debug|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Release|x64.ActiveCfg = Release|Any CPU
+		{A3A1AFA7-6214-4624-80F6-B17B60B36916}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The existing auto-download code worked for _most_ scenarios, but there were a few it mishandled. In its existing state it was difficult to modify, so I chose to heavily refactor it.

- The algorithm is now unit testable, and I have added tests to do this. These cover scenarios that are awkward to test manually.
- I removed error message passing from the control flow - it's just confusing to read. I can't get away from Unity's kludgy coroutine handling, but at least we don't need to overload it with unrelated things.

I should note that it will probably still struggle with levels distributed as raw .mp (and associated) files, but as far as I know overloadmaps doesn't allow this anyway, so no big deal.

Since I have added a new .csproj it would be appreciated if someone else could "test build" this to make sure it also builds for people who are not me. Hoping to sanity-test this in Overload soon but at the time of writing people are repeatedly playing Wraith and Vault which are not affected by auto-download...