### PR TITLE
Allow boss2b to be used as a boss

### DIFF
--- a/GameMod/Boss2B.cs
+++ b/GameMod/Boss2B.cs
@@ -1,0 +1,23 @@
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using UnityEngine;
+
+namespace GameMod
+{
+    // Allow boss2b (unused boss) to trigger exit sequence when destroyed during a boss lockdown.
+    [HarmonyPatch(typeof(Robot), "ExplodeNow")]
+    public class Robot_ExplodeNow_Boss2B
+    {
+        static void Postfix(Robot __instance)
+        {
+            if(__instance.m_is_boss && __instance.robot_type == Overload.EnemyType.BOSS2B)
+            {
+                Overload.GameplayManager.LockdownBossDestroyed();
+            }
+        }
+    }
+}

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -207,6 +207,7 @@
     <Compile Include="VersionHandling\PatchVersionInfo.cs" />
     <Compile Include="VRScale.cs" />
     <Compile Include="VSync.cs" />
+    <Compile Include="Boss2B.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="0Harmony.dll" />


### PR DESCRIPTION
This change allows the (not officially used) boss2b robot to end the level when used in a Lockdown Boss script.
This is helpful for custom missions because the Cronus Frontier bosses cannot be customized using robotdata files; only this boss can be customized.