### PR TITLE
Fixed ship disappearing during exit cutscene

### DIFF
--- a/GameMod/ExitCutscene.cs
+++ b/GameMod/ExitCutscene.cs
@@ -1,0 +1,27 @@
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using UnityEngine;
+
+namespace GameMod
+{
+    // If a cloaking device expires during the exit cutscene,
+    // cockpit visibility (which is also used to show the ship in cutscenes)
+    // reverts to the profile setting even though we want it forced on.
+    [HarmonyPatch(typeof(Overload.PlayerShip), "get_IsCockpitVisible")]
+    public class PlayerShip_IsCockpitVisible_DuringExit
+    {
+        static bool Prefix(ref bool __result)
+        {
+            if (Overload.GameplayManager.m_gameplay_state == Overload.GameplayState.EXIT)
+            {
+                __result = true;
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Menus.cs" />
     <Compile Include="Shaders.cs" />
     <Compile Include="WarperOrientation.cs" />
+    <Compile Include="ExitCutscene.cs" />
     <Compile Include="UIMeshColliderNoRender.cs" />
     <Compile Include="VersionHandling\OlmodVersion.cs" />
     <Compile Include="VersionHandling\PatchVersionInfo.cs" />


### PR DESCRIPTION
As far as I can tell, the ship model shown during the exit cutscene in a single player level is actually also the cockpit model, and is supposed to be forced on when first entering the exit. But when a cloak wears off, the cockpit's visibility reverts to the setting the player had before going in.
This change might be a little hacky but it makes sure the setting stays on during the cutscene.