### PR TITLE
Disable the rendering of the cockpits of opponent ships in multiplayer

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -153,6 +153,7 @@
     <Compile Include="MPMonoDNSFix.cs" />
     <Compile Include="MPNoDupes.cs" />
     <Compile Include="MPNoPositionCompression.cs" />
+    <Compile Include="MPOpponentCockpits.cs" />
     <Compile Include="MPPickupCheck.cs" />
     <Compile Include="MPPrimaries.cs" />
     <Compile Include="MPRespawn.cs" />

--- a/GameMod/MPJoinInProgress.cs
+++ b/GameMod/MPJoinInProgress.cs
@@ -67,6 +67,7 @@ namespace GameMod {
             if (ready)
             {
                 player.c_player_ship.RestoreLights();
+                MPOpponentCockpits.SetOpponentCockpitVisibility(player,false);
             }
             else
             {

--- a/GameMod/MPOpponentCockpits.cs
+++ b/GameMod/MPOpponentCockpits.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Reflection;
+using HarmonyLib;
+using Overload;
+using UnityEngine;
+
+namespace GameMod {
+    public class MPOpponentCockpits {
+        public static void SetOpponentCockpitVisibility(Player p, bool enabled) {
+            if (p != null && p.c_player_ship != null && !p.isLocalPlayer && !p.m_spectator) {
+                //Debug.LogFormat("Setting cockpit visibility for player ship {0} to {1}",p.m_mp_name, enabled);
+                MeshRenderer[] componentsInChildren = p.c_player_ship.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
+                foreach (MeshRenderer meshRenderer in componentsInChildren)
+                {
+                    if (meshRenderer.enabled != enabled) {
+                        if (string.CompareOrdinal(meshRenderer.name, 0, "cp_", 0, 3) == 0) {
+                            meshRenderer.enabled = enabled;
+                            meshRenderer.shadowCastingMode = 0;
+                        }
+                    }
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(Overload.PlayerShip), "SetCockpitVisibility")]
+        class MPOpponentCockpits_Disable1 {
+            static void Postfix(PlayerShip __instance) {
+                SetOpponentCockpitVisibility(__instance.c_player, false);
+            }
+        }
+
+        [HarmonyPatch(typeof(Overload.Player), "RestorePlayerShipDataAfterRespawn")]
+        class MPOpponentCockpits_Disable2 {
+            static void Postfix(Player __instance) {
+                SetOpponentCockpitVisibility(__instance, false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
They are completely occluded by the ship hull mesh, so they are never visible.

The performance gain from this is negligible, though.  I measured an FPS increase of < 1% with 4 opponent ships visible. However, my system seems to be mostly CPU-bound, there _might_ be a slightly higher gain on other
systems. 

The patch is fairly simple and it doesn't hurt, so I'm offering it for inclusion into olmod. YMMV.