### PR TITLE
Add a `/SWITCHTEAM` chat command

### DIFF
--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -1354,9 +1354,8 @@ namespace GameMod
     [HarmonyPatch(typeof(Server), "RegisterHandlers")]
     class MPTeams_Server_RegisterHandlers
     {
-        private static void OnChangeTeam(NetworkMessage rawMsg)
+        public static void DoChangeTeam(MPTeams.ChangeTeamMessage msg)
         {
-            var msg = rawMsg.ReadMessage<MPTeams.ChangeTeamMessage>();
             var targetPlayer = Overload.NetworkManager.m_Players.FirstOrDefault(x => x.netId == msg.netId);
 
             ServerStatLog.AddTeamChange(targetPlayer, msg.newTeam);
@@ -1390,6 +1389,12 @@ namespace GameMod
                 if (MPTweaks.ClientHasTweak(player.connectionToClient.connectionId, "changeteam"))
                     NetworkServer.SendToClient(player.connectionToClient.connectionId, MessageTypes.MsgChangeTeam, msg);
             }
+        }
+
+        private static void OnChangeTeam(NetworkMessage rawMsg)
+        {
+            var msg = rawMsg.ReadMessage<MPTeams.ChangeTeamMessage>();
+            DoChangeTeam(msg);
         }
 
         static void Postfix()

--- a/ServerCommands.md
+++ b/ServerCommands.md
@@ -22,6 +22,7 @@ see [the section on privilege management below](#privilege-management) for detai
  * `/STATUS`: short info about chat command and ban status. No permission required for this command.
  * `/SAY`: send a message to all players which are not blocked for chat
  * `/TEST <player>`: Test player name selection. No permission required for this command.
+ * `/SWITCHTEAM [<player>]`: Switch the team a player is in. If used without an argument, it affects the player sending this command. Switching teams for players other than yourself requires chat command permissions.
 
 ### Player Name Matching
 


### PR DESCRIPTION
This allows players with chat command permission to switch the team of any player (both in lobby and in-game). This might especially help re-balancing public JIP team anarchy games.