### PR TITLE
Fix in-game FPS measurement

### DIFF
--- a/GameMod/FrameTime.cs
+++ b/GameMod/FrameTime.cs
@@ -3,6 +3,8 @@ using Overload;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Text;
 using UnityEngine;
 
@@ -14,6 +16,81 @@ namespace GameMod
         private static void Postfix()
         {
             GameManager.m_display_fps = Menus.mms_show_framerate;
+        }
+    }
+
+    // fix the FPS calculation
+    [HarmonyPatch(typeof(UIElement), "DrawHUD")]
+    class FixFPSCalculation
+    {
+        private static uint lastMeasurementCount = 0;
+        private static float lastMeasurementTime = 0.0f;
+        private static float currentFrameTime = 0.1f;
+        private static float currentDuration = 0.1f;
+        private static float currentFPS = 0.0f;
+        private static MethodInfo our_Method = AccessTools.Method(typeof(FixFPSCalculation), "CalculateFPS");
+
+        private static float CalculateFPS()
+        {
+           const float intervalLength = 1.0f; // duration (seconds) of base FPS measurement interval
+           float now = Time.realtimeSinceStartup;
+           float duration = now - lastMeasurementTime;
+           uint frameCount = (uint)Time.frameCount;
+           uint frames = (frameCount - lastMeasurementCount);
+           if (frames > 0) {
+               float newFrameTime = duration / frames;
+               if (duration >= intervalLength) {
+                    // take average frame time during the interval
+                   currentFrameTime = newFrameTime;
+                   currentDuration = duration;
+                   lastMeasurementCount = frameCount;
+                   lastMeasurementTime = now;
+                   currentFPS = 1.0f / currentFrameTime;
+               } else {
+                   // mix the previous interval with the new data since then
+                   // weighted on the difference of durations
+                   float factor = duration / currentDuration;
+                   if (factor > 1.0f) {
+                       factor = 1.0f;
+                   }
+                   float avgFrameTime = factor * newFrameTime + (1.0f - factor) * currentFrameTime;
+                   currentFPS = 1.0f / avgFrameTime;
+               }
+           }
+           return currentFPS;
+        }
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            int state = 0;
+
+            foreach (var code in codes)
+            {
+                bool emitInstruction = true;
+                //Debug.LogFormat("YYTS: {0} {1} {2}",state,code.opcode,code.operand);
+                if (state == 0) {
+                    /// Search the start of the average_fps calculation
+                    if (code.opcode == OpCodes.Ldsfld && ((FieldInfo)code.operand).Name == "average_fps") {
+                        state = 1;
+                        emitInstruction = false;
+                    }
+                } else if (state == 1) {
+                    // Search the end of the average_fps calculation
+                    if (code.opcode == OpCodes.Add) {
+                        state = 2;
+                        // call our calculation method instead
+                        yield return new CodeInstruction(OpCodes.Call, our_Method);
+                    }
+                    // omit the original calculation code
+                    emitInstruction = false;
+                }
+                if (emitInstruction) {
+                    yield return code;
+                }
+            }
+            if (state != 2) {
+                Debug.LogFormat("FixFPSCalculation: transpiler failed at state {0}",state);
+            }
         }
     }
 }


### PR DESCRIPTION
Overload's FPS measurement is broken. There are two issues:

1. Conceptually, the code tries to build an average of the FPS value _per frame_, which means averaging the `1/frametime`s. This is wrong on a fundamental level. Consider the following (rather extreme, but illustrative) example: The game renders frames in alternating patterns of 8ms followed by 32ms. The "averaging FPS" algorithm will do `(1/0.008 + 1/0.032)/2` and yield 78.125 fps. However, in reality there are two frames every 40ms, the average frame time is 20ms, and the actual frame rate is 50 fps.
2. The code doesn't do a proper gliding average calculation, but rather uses a non-linear smoothing formula with a dampening factor: `average_fps = 0.095 * average_fps + 0.05 * (1/frametime)`. This formula in combination from the issue of point 1 actually biases towards higher FPS values.

Overall, Overload's calculation works nice when there is very little variation in individual frame times (like when playing with VSync). However, the bigger the variances get, the more off the value gets, and it generally tends to _oversell_ the actual performance.

Here is some real-world data. This is my system, challenge mode in Blizzard, VSync disabled, with the correct values and Overload's result logged every 1/4 second:

```
FPS: mine 165.8514, overload's: 177.1141
FPS: mine 161.6956, overload's: 171.4508
FPS: mine 163.0323, overload's: 169.7437
FPS: mine 160.2156, overload's: 174.9055
FPS: mine 157.574, overload's: 164.166
```

So it is overselling stuff by 5% to 10% for me, but also the individual variations it shows don't really represent real data (a single very short frame will be amplified).

However, this isn't the worst case. I was experimenting with VSync stuff and accidentally screwed up the frame pacing - and this is also how I noticed the issue in the first place. I knew I was limited to ~120fps, but the game would report stuff in the 130 to 200 fps range:

```
FPS: mine 119.7515, overload's: 194.5012
FPS: mine 122.8212, overload's: 172.5413
FPS: mine 119.7624, overload's: 171.2341
FPS: mine 116.312, overload's: 159.3552
FPS: mine 120.0541, overload's: 176.3961
FPS: mine 122.4096, overload's: 178.2538
FPS: mine 119.9085, overload's: 161.1803
FPS: mine 118.3615, overload's: 199.2826
FPS: mine 119.967, overload's: 208.0596
```

So in other words, in worst case scenarios, the numbers which got displayed are _complete bullshit_, overselling the framerate by 50% and more, and showing variations which just aren't there.

This patch replaces the averaging FPS calculation by a sane algorithm. The values I get now closely match the measurements I get from my graphic driver's in-built FPS overlay.

The only downside of this patch is that people may _think_ the new olmod version degraded their rendering performance, while in reality, the game just stopped lying to them...