### PR TITLE
Fix a few issues in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ This is an unaffiliated, unsupported tool. Use at your own risk.
 
 - Puts a MP player in observer mode if it uses a pilot name starting with OBSERVER. The observer mode only works when the server and the observer client run olmod.
 
-- Reads `&lt;level name>-projdata.txt` / `&lt;level name>-robotdata.txt` for levels, `&lt;mission name>-projdata.txt` / `&lt;level name>-robotdata.txt` for missions, and `projdata.txt` / `robotdata.txt` in the olmod directory for testing.  These files can have custom projectile (weapon) and robot settings. You can extract the stock data from the game with the included tool `olgetdata`. The txt files must be in the same directory as olmod.exe. You can run olgetdata on linux with `mono olgetdata.exe`. They can either go in the olmod directory, or map makers can add them to their map .zip files.
-
-- Adds `frametime` non-cheat code
+- Reads `<level name>-projdata.txt` / `<level name>-robotdata.txt` for levels, `<mission name>-projdata.txt` / `<level name>-robotdata.txt` for missions, and `projdata.txt` / `robotdata.txt` in the olmod directory for testing.  These files can have custom projectile (weapon) and robot settings. You can extract the stock data from the game with the included tool `olgetdata`. The txt files must be in the same directory as olmod.exe. You can run olgetdata on linux with `mono olgetdata.exe`. They can either go in the olmod directory, or map makers can add them to their map .zip files.
 
 - Adds a rearview option for all game modes, with an option to allow it in a multiplayer game
 

--- a/README.txt
+++ b/README.txt
@@ -31,9 +31,7 @@ What does it do
 
 - Puts a MP player in observer mode if it uses a pilot name starting with OBSERVER. The observer mode only works when the server and the observer client run olmod.
 
-- Reads `&lt;level name>-projdata.txt` / `&lt;level name>-robotdata.txt` for levels, `&lt;mission name>-projdata.txt` / `&lt;level name>-robotdata.txt` for missions, and `projdata.txt` / `robotdata.txt` in the olmod directory for testing.  These files can have custom projectile (weapon) and robot settings. You can extract the stock data from the game with the included tool `olgetdata`. The txt files must be in the same directory as olmod.exe. You can run olgetdata on linux with `mono olgetdata.exe`. They can either go in the olmod directory, or map makers can add them to their map .zip files.
-
-- Adds `frametime` non-cheat code
+- Reads `<level name>-projdata.txt` / `<level name>-robotdata.txt` for levels, `<mission name>-projdata.txt` / `<level name>-robotdata.txt` for missions, and `projdata.txt` / `robotdata.txt` in the olmod directory for testing.  These files can have custom projectile (weapon) and robot settings. You can extract the stock data from the game with the included tool `olgetdata`. The txt files must be in the same directory as olmod.exe. You can run olgetdata on linux with `mono olgetdata.exe`. They can either go in the olmod directory, or map makers can add them to their map .zip files.
 
 - Adds a rearview option for all game modes, with an option to allow it in a multiplayer game
 


### PR DESCRIPTION
- Remove the mention of the `frametime` non-cheat code as this  was removed when the menu option was added
- Fix the encoding of opening angle bracket using html syntax
  * In markdown, when used inside code blocks or code spans, the ampersand and angle brackets are displayed as-is (internally converted to the HTML escapes), and must not be encoded by HTML rules
  * In the txt file, the escape never made sense