### PR TITLE
Fix menu handling for Create Match -> Advanced -> Allow Rear View Camera

### DIFF
--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -389,6 +389,10 @@ namespace GameMod {
             {
                 switch (UIManager.m_menu_selection)
                 {
+                    case 11:
+                        RearView.MPMenuManagerEnabled = !RearView.MPMenuManagerEnabled;
+                        MenuManager.PlayCycleSound(1f, (float)UIManager.m_select_dir);
+                        break;
                     case 13:
                         Menus.mms_classic_spawns = !Menus.mms_classic_spawns;
                         MenuManager.PlayCycleSound(1f, (float)UIManager.m_select_dir);


### PR DESCRIPTION
This likely got clobbered at some point during a menu re-org, added in handler.  Addresses Issue #242 