### PR TITLE
Add "Toggle Loadout Primary" keybinding

### DIFF
--- a/GameMod/ControlsExt.cs
+++ b/GameMod/ControlsExt.cs
@@ -1,0 +1,258 @@
+﻿using HarmonyLib;
+using Overload;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace GameMod
+{
+    internal class ControlsExt
+    {
+        public static int MAX_ARRAY_SIZE = Enum.GetValues(typeof(CCInputExt)).Cast<int>().Max() + 1;
+
+        public static string GetInputName(CCInputExt cc)
+        {
+            switch (cc)
+            {
+                case CCInputExt.TOGGLE_LOADOUT_PRIMARY:
+                    return Loc.LS("TOGGLE LOADOUT PRIMARY");
+                default:
+                    return Loc.LS("UNKNOWN");
+            }
+        }
+
+        public static int GetExclusionMask(CCInputExt input)
+        {
+            switch (input)
+            {
+                case CCInputExt.WHEEL_LEFT:
+                case CCInputExt.WHEEL_RIGHT:
+                case CCInputExt.WHEEL_UP:
+                case CCInputExt.WHEEL_DOWN:
+                    return 2;
+                default:
+                    switch (input)
+                    {
+                        case CCInputExt.HOLOGUIDE:
+                        case CCInputExt.PREV_WEAPON:
+                        case CCInputExt.PREV_MISSILE:
+                            break;
+                        default:
+                            if (input != CCInputExt.SWITCH_WEAPON && input != CCInputExt.SWITCH_MISSILE)
+                            {
+                                return 1;
+                            }
+                            break;
+                    }
+                    return 3;
+            }
+        }
+    }
+
+    public enum CCInputExt
+    {
+        TURN_LEFT,
+        TURN_RIGHT,
+        PITCH_UP,
+        PITCH_DOWN,
+        ROLL_LEFT,
+        ROLL_RIGHT,
+        MOVE_FORE,
+        MOVE_BACK,
+        SLIDE_LEFT,
+        SLIDE_RIGHT,
+        SLIDE_UP,
+        SLIDE_DOWN,
+        ROLL_LEFT_90,
+        ROLL_RIGHT_90,
+        FIRE_WEAPON,
+        FIRE_MISSILE,
+        SWITCH_WEAPON,
+        SWITCH_MISSILE,
+        FIRE_FLARE,
+        USE_BOOST,
+        TOGGLE_HEADLIGHT,
+        VIEW_MAP,
+        HOLOGUIDE,
+        SMASH_ATTACK,
+        REAR_VIEW,
+        PREV_WEAPON,
+        PREV_MISSILE,
+        SLIDE_MODIFIER,
+        QUICKSAVE,
+        TOGGLE_COCKPIT,
+        FULL_CHAT,
+        TOGGLE_HUD,
+        RECENTER_VR,
+        WEAPON_1x2,
+        WEAPON_3x4,
+        WEAPON_5x6,
+        WEAPON_7x8,
+        MISSILE_1x2,
+        MISSILE_3x4,
+        MISSILE_5x6,
+        MISSILE_7x8,
+        WHEEL_LEFT,
+        WHEEL_RIGHT,
+        WHEEL_UP,
+        WHEEL_DOWN,
+        MENU_UP,
+        MENU_DOWN,
+        MENU_LEFT,
+        MENU_RIGHT,
+        MENU_SELECT,
+        MENU_BACK,
+        MENU_DELETE,
+        MENU_SECONDARY,
+        MENU_RECENTER,
+        MENU_PGUP,
+        MENU_PGDN,
+        MENU_HOME,
+        MENU_END,
+        PAUSE,
+        NUM,
+        NUM_CONFIGURABLE = 45,
+        // Start of new entries
+        TOGGLE_LOADOUT_PRIMARY = 60
+    };
+
+    [HarmonyPatch(typeof(PlayerShip), "UpdateReadImmediateControls")]
+    internal class ControlsExt_PlayerShip_UpdateReadImmediateControls
+    {
+        static void Postfix(PlayerShip __instance)
+        {
+            if (MPObserver.Enabled)
+                return;
+
+            if (Controls.JustPressed((CCInput)CCInputExt.TOGGLE_LOADOUT_PRIMARY) && GameplayManager.IsMultiplayerActive)
+            {
+                MPLoadouts.ToggleLoadoutPrimary(__instance.c_player);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Player), MethodType.Constructor)]
+    internal class ControlsExt_Player_Constructor
+    {
+        static void Postfix(Player __instance)
+        {
+            Array.Resize<int>(ref __instance.m_input_count, ControlsExt.MAX_ARRAY_SIZE);
+        }
+    }
+
+    [HarmonyPatch(typeof(Controls), "InitControl")]
+    internal class ControlsExt_Controls_InitControl
+    {
+        static void Prefix()
+        {
+            Controls.m_input_joy = new RWInput[2, ControlsExt.MAX_ARRAY_SIZE];
+            Controls.m_input_kc = new KeyCode[2, ControlsExt.MAX_ARRAY_SIZE];
+            Controls.m_input_count = new int[ControlsExt.MAX_ARRAY_SIZE];
+        }
+    }
+
+    [HarmonyPatch]
+    internal class ControlsExt_PatchArraySizes
+    {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Controls), "UpdateDevice");
+            yield return AccessTools.Method(typeof(Controls), "ClearKBMouse");
+            yield return AccessTools.Method(typeof(Controls), "ClearControlsForController");
+            yield return AccessTools.Method(typeof(PlayerShip), "UpdateReadImmediateControls");
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            foreach (var code in codes)
+            {
+                if (code.opcode == OpCodes.Ldc_I4 && (int)code.operand == 59)
+                    code.operand = ControlsExt.MAX_ARRAY_SIZE;
+
+                if (code.opcode == OpCodes.Ldc_I4_S && (sbyte)code.operand == 59)
+                    code.operand = (sbyte)ControlsExt.MAX_ARRAY_SIZE;
+
+                yield return code;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The control pairing for a given CCInput is based on passed CCInput value and CCInput value + 50.
+    /// We need to bump this out further to differentiate CCInput values > 50 from their alt representation.
+    /// </summary>
+    [HarmonyPatch(typeof(UIElement), "SelectAndDrawControlOption")]
+    internal class ControlsExt_UIElement_SelectAndDrawControlOption
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            foreach (var code in codes)
+            {
+                if (code.opcode == OpCodes.Ldc_I4_S && (sbyte)code.operand == 50)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldc_I4, 1000);
+                    continue;
+                }
+                yield return code;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Controls), "ClearMatchingControls")]
+    internal class ControlsExt_Controls_ClearMatchingControls
+    {
+        static bool Prefix(int mask, RWInput rwi)
+        {
+            for (int i = 0; i < 45; i++)
+            {
+                if ((mask & ControlsExt.GetExclusionMask((CCInputExt)i)) != 0)
+                {
+                    if (Controls.m_input_joy[0, i].Match(rwi))
+                    {
+                        Controls.m_input_joy[0, i].Clear();
+                    }
+                    if (Controls.m_input_joy[1, i].Match(rwi))
+                    {
+                        Controls.m_input_joy[1, i].Clear();
+                    }
+                }
+            }
+            for (int i = (int)CCInputExt.TOGGLE_LOADOUT_PRIMARY; i < ControlsExt.MAX_ARRAY_SIZE; i++)
+            {
+                if ((mask & ControlsExt.GetExclusionMask((CCInputExt)i)) != 0)
+                {
+                    if (Controls.m_input_joy[0, i].Match(rwi))
+                    {
+                        Controls.m_input_joy[0, i].Clear();
+                    }
+                    if (Controls.m_input_joy[1, i].Match(rwi))
+                    {
+                        Controls.m_input_joy[1, i].Clear();
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Controls), "SetInputJoystick")]
+    internal class ControlsExt_Controls_SetInputJoystick
+    {
+        private static MethodInfo _ClearMatchingControls_Method = AccessTools.Method(typeof(Controls), "ClearMatchingControls");
+
+        static bool Prefix(int idx, bool alt, RWInput rwi)
+        {
+            int exclusionMask = ControlsExt.GetExclusionMask((CCInputExt)idx);
+            _ClearMatchingControls_Method.Invoke(null, new object[] { exclusionMask, rwi });
+            int num = (!alt) ? 0 : 1;
+            Controls.m_input_joy[num, idx].Copy(rwi);
+
+            return false;
+        }
+    }
+}

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -103,6 +103,7 @@
     <Compile Include="Config.cs" />
     <Compile Include="Console.cs" />
     <Compile Include="Controllers.cs" />
+    <Compile Include="ControlsExt.cs" />
     <Compile Include="CrusherTrails.cs" />
     <Compile Include="HUDVelocity.cs" />
     <Compile Include="DisableProfanityFilter.cs" />

--- a/GameMod/MPAnticheat.cs
+++ b/GameMod/MPAnticheat.cs
@@ -41,16 +41,6 @@ namespace GameMod
         }
     }
 
-    [HarmonyPatch(typeof(Controls), "SetInputKB")]
-
-    internal class SetInputKB
-    {
-        private static bool Prefix(int idx, KeyCode kc)
-        {
-            return idx != 14 && idx != 15 || kc != KeyCode.Joystick8Button10 && kc != KeyCode.Joystick8Button11;
-        }
-    }
-
     [HarmonyPatch(typeof(Controls), "ReadControlData")]
     internal class ReadControlData
     {

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -152,6 +152,38 @@ namespace GameMod
                 MPLoadouts.Loadouts[loadoutIndex].missiles[missileIndex] = (MissileType)((((int)MPLoadouts.Loadouts[loadoutIndex].missiles[missileIndex]) + 1) % (int)MissileType.NOVA);
         }
 
+        // Action for input binding "Toggle Loadout Primary"
+        public static void ToggleLoadoutPrimary(Player player)
+        {
+            var nextWeapon = WeaponType.NUM;
+            if (NetworkMatch.m_force_loadout == 1 && NetworkMatch.m_force_w2 != WeaponType.NUM)
+            {
+                nextWeapon = NetworkMatch.m_force_w1 == player.m_weapon_type ? NetworkMatch.m_force_w2 : NetworkMatch.m_force_w1;
+            }
+            else
+            {
+                var currentLoadout = MPLoadouts.Loadouts[Menus.mms_selected_loadout_idx];
+                if (currentLoadout.loadoutType == MPLoadouts.LoadoutType.BOMBER)
+                {
+                    nextWeapon = currentLoadout.weapons[0];
+                }
+                else
+                {
+                    nextWeapon = currentLoadout.weapons[0] != player.m_weapon_type
+                        ? currentLoadout.weapons[0]
+                        : currentLoadout.weapons[1];
+                }
+            }
+
+            if (nextWeapon == WeaponType.NUM || nextWeapon == player.m_weapon_type)
+                return;
+
+            player.Networkm_weapon_type = nextWeapon;
+            player.CallCmdSetCurrentWeapon(player.m_weapon_type);
+            player.c_player_ship.WeaponSelectFX();
+            player.UpdateCurrentWeaponName();
+        }
+
         public static void SendPlayerLoadoutToServer()
         {
             if (Client.GetClient() == null)


### PR DESCRIPTION
- Adds new binding in Additional Controls for keyboard/mouse/joystick/controllers.
- Introduces new "CCInputExt" and surrounding changes if further custom bindings are needed in the future.
- Data stored in pilot.xconfigmod in the same fashion as pilot.xconfig to avoid data issues switching between vanilla and olmod.
- Moved logic of a SetInputKB prefix from MPAnticheat.cs, original intent of that may need verified.