### PR TITLE
Improve debug logging for autodownloader

### DIFF
--- a/GameMod/MPDownloadLevel.cs
+++ b/GameMod/MPDownloadLevel.cs
@@ -45,6 +45,11 @@ namespace GameMod
 
         private static bool ZipContainsLevel(string zipFilename, string levelIdHash)
         {
+            if (!File.Exists(zipFilename))
+            {
+                Debug.Log($"ZipContainsLevel: File \"{zipFilename}\" not found");
+                return false;
+            }
             string[] parts = levelIdHash.Split(new[] { ':' });
             string levelFile = parts[0];
             if (!int.TryParse(parts[1], NumberStyles.HexNumber, null, out int hash))
@@ -154,6 +159,7 @@ namespace GameMod
 
         private static void OnDownloadFailed()
         {
+            Debug.Log("MPDownloadLevel.OnDownloadFailed");
             DownloadBusy = false;
             if (Overload.NetworkManager.IsServer())
             {
@@ -165,6 +171,7 @@ namespace GameMod
         private static FieldInfo _NetworkMatch_m_match_force_playlist_level_idx_Field = typeof(NetworkMatch).GetField("m_match_force_playlist_level_idx", BindingFlags.NonPublic | BindingFlags.Static);
         private static void OnDownloadCompleted(int newLevelIndex)
         {
+            Debug.Log($"MPDownloadLevel.OnDownloadCompleted (newLevelIndex={newLevelIndex})");
             if (Overload.NetworkManager.IsServer())
             {
                 _NetworkMatch_m_match_force_playlist_level_idx_Field.SetValue(null, newLevelIndex);


### PR DESCRIPTION
Some minor improvements intended to make it easier to see what's going on in cases like the log luponix sent.

- We probably don't want "file not found" to throw an exception that gets recorded to the debug log - that makes it look like there is a problem when there isn't. It just means we need to download the level.
- Added traces to for OnDownloadCompleted/OnDownloadFailed getting called. This helps narrow down whether the problem is on the side of the autodownloader, or the coroutine waiting for it.