### PR TITLE
Optimizations v2

### DIFF
--- a/GameMod/MPDirectionalWarning.cs
+++ b/GameMod/MPDirectionalWarning.cs
@@ -11,21 +11,14 @@ namespace GameMod
 {
     public static class MPDirectionalWarning
     {
-        public static Vector3 homingDir = Vector3.zero;
+        public static Transform homingPos;
 
-        public static void SetDirection(Player p, Transform t)
-        {
-            if (Menus.mms_directional_warnings)
-            {
-                homingDir = Vector3.MoveTowards(p.c_player_ship.transform.localPosition, t.localPosition, 0.7f);
-            }
-        }
-
+        // calculates direction and plays cues in 3D if it's enabled in the menu setting, otherwise use the 2D cue call
         public static void PlayCueWarning(SFXCue sfx_type, float vol_mod = 1f, float pitch_mod = 0f, float delay = 0f, bool reverb = false)
         {
-            //Debug.Log("CCC playing homing cue at position " + homingDir + ", ship position is " + GameManager.m_player_ship.transform.localPosition);
             if (Menus.mms_directional_warnings)
             {
+                Vector3 homingDir = Vector3.MoveTowards(GameManager.m_player_ship.c_transform_position, homingPos.localPosition, 0.7f);
                 SFXCueManager.PlayCuePos(sfx_type, homingDir, vol_mod, pitch_mod, false, delay, 1f);
             }
             else
@@ -35,6 +28,7 @@ namespace GameMod
         }
     }
 
+    // stores the Transform of the homing projectile in MPDirectionalWarning for use during 3D cue playback
     [HarmonyPatch(typeof(Projectile), "SteerTowardsTarget")]
     internal class MPDirectionalWarning_Projectile_SteerTowardsTarget
     {
@@ -47,15 +41,14 @@ namespace GameMod
                 if (code.opcode == OpCodes.Stsfld && code.operand == AccessTools.Field(typeof(Projectile), "PlayerLockOnMinDistanceSq"))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
-                    yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Projectile), "m_cur_target_player"));
-                    yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Projectile), "c_transform"));
-                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPDirectionalWarning), "SetDirection"));
+                    yield return new CodeInstruction(OpCodes.Stsfld, AccessTools.Field(typeof(MPDirectionalWarning), "homingPos"));
                 }
             }
         }
     }
 
+    // same as above for creepers
     [HarmonyPatch(typeof(Projectile), "MoveTowardsTarget")]
     internal class MPDirectionalWarning_Projectile_MoveTowardsTarget
     {
@@ -68,15 +61,14 @@ namespace GameMod
                 if (code.opcode == OpCodes.Stsfld && code.operand == AccessTools.Field(typeof(Projectile), "PlayerLockOnMinDistanceSq"))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
-                    yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Projectile), "m_cur_target_player"));
-                    yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Projectile), "c_transform"));
-                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPDirectionalWarning), "SetDirection"));
+                    yield return new CodeInstruction(OpCodes.Stsfld, AccessTools.Field(typeof(MPDirectionalWarning), "homingPos"));
                 }
             }
         }
     }
 
+    // swaps out the call for the homing cues to the new method that determines which one should be used
     [HarmonyPatch(typeof(PlayerShip), "Update")]
     internal class MPDirectionalWarning_PlayerShip_Update
     {

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -685,27 +685,95 @@ namespace GameMod
     {
         public static void LoadoutSelect(PlayerShip ps)
         {
-            if (Menus.mms_loadout_hotkeys && !PlayerShip.m_typing_in_chat && NetworkMatch.m_force_loadout == 0 && (float)ps.m_dying_timer < 2.5f)
+            if (!PlayerShip.m_typing_in_chat && NetworkMatch.m_force_loadout == 0 && (float)ps.m_dying_timer < 2.5f)
             {
-                if (Controls.JustPressed(CCInput.WEAPON_1x2))
+                switch (Menus.mms_loadout_hotkeys)
                 {
-                    MPLoadouts.SendCustomLoadoutToServer(0);
-                    MenuManager.PlayCycleSound();
-                }
-                else if (Controls.JustPressed(CCInput.WEAPON_3x4))
-                {
-                    MPLoadouts.SendCustomLoadoutToServer(1);
-                    MenuManager.PlayCycleSound();
-                }
-                else if (Controls.JustPressed(CCInput.WEAPON_5x6))
-                {
-                    MPLoadouts.SendCustomLoadoutToServer(2);
-                    MenuManager.PlayCycleSound();
-                }
-                else if (Controls.JustPressed(CCInput.WEAPON_7x8))
-                {
-                    MPLoadouts.SendCustomLoadoutToServer(3);
-                    MenuManager.PlayCycleSound();
+                    // weapon selection using Primary 1/2, 3/4, 5/6, 7/8
+                    case 1:
+                        if (Controls.JustPressed(CCInput.WEAPON_1x2))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(0);
+                            MenuManager.PlayCycleSound();
+                        }
+                        else if (Controls.JustPressed(CCInput.WEAPON_3x4))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(1);
+                            MenuManager.PlayCycleSound();
+                        }
+                        else if (Controls.JustPressed(CCInput.WEAPON_5x6))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(2);
+                            MenuManager.PlayCycleSound();
+                        }
+                        else if (Controls.JustPressed(CCInput.WEAPON_7x8))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(3);
+                            MenuManager.PlayCycleSound();
+                        }
+                        break;
+
+                    // weapon selection using Primary 1, 2, 3, 4
+                    case 2:
+                        if (Controls.JustPressed(CCInput.WEAPON_1x2))
+                        {
+                            if (Controls.BothAssigned(CCInput.WEAPON_1x2))
+                            {
+                                if (Controls.PressedSlot(CCInput.WEAPON_1x2, 0))
+                                {
+                                    MPLoadouts.SendCustomLoadoutToServer(0);
+                                }
+                                else
+                                {
+                                    MPLoadouts.SendCustomLoadoutToServer(1);
+                                }
+                                MenuManager.PlayCycleSound();
+                            }
+                        }
+                        else if (Controls.JustPressed(CCInput.WEAPON_3x4))
+                        {
+                            if (Controls.BothAssigned(CCInput.WEAPON_3x4))
+                            {
+                                if (Controls.PressedSlot(CCInput.WEAPON_3x4, 0))
+                                {
+                                    MPLoadouts.SendCustomLoadoutToServer(2);
+                                }
+                                else
+                                {
+                                    MPLoadouts.SendCustomLoadoutToServer(3);
+                                }
+                                MenuManager.PlayCycleSound();
+                            }
+                        }
+                        break;
+
+                    // weapon selection using number & numpad keys 1-4 on the keyboard only
+                    case 3:
+                        if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(0);
+                            MenuManager.PlayCycleSound();
+                        }
+                        else if (Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(1);
+                            MenuManager.PlayCycleSound();
+                        }
+                        else if (Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(2);
+                            MenuManager.PlayCycleSound();
+                        }
+                        else if (Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4))
+                        {
+                            MPLoadouts.SendCustomLoadoutToServer(3);
+                            MenuManager.PlayCycleSound();
+                        }
+                        break;
+
+                    // disabled
+                    default:
+                        break;
                 }
             }
         }

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -273,7 +273,7 @@ namespace GameMod {
                 MPLoadouts.Loadouts[3].weapons[1] = (WeaponType)ModPrefs.GetInt("MP_PM_LOADOUT_GUNNER2_W2", (int)MPLoadouts.Loadouts[1].weapons[1]);
                 MPLoadouts.Loadouts[3].missiles[0] = (MissileType)ModPrefs.GetInt("MP_PM_LOADOUT_GUNNER2_M1", (int)MPLoadouts.Loadouts[1].missiles[0]);
             }
-            else // for compatability with old olmod, no need to add new settings
+            else // for compatibility with old olmod, no need to add new settings
             {
                 MPTeams.MenuManagerTeamCount = MenuManager.LocalGetInt("MP_PM_TEAM_COUNT", MPTeams.MenuManagerTeamCount);
                 MPJoinInProgress.MenuManagerEnabled = MenuManager.LocalGetBool("MP_PM_JIP", MPJoinInProgress.MenuManagerEnabled);

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -255,7 +255,7 @@ namespace GameMod {
                 Menus.mms_show_framerate = ModPrefs.GetBool("MP_PM_SHOWFRAMERATE", Menus.mms_show_framerate);
                 Menus.mms_audio_occlusion_strength = ModPrefs.GetInt("MP_PM_AUDIO_OCCLUSION_STRENGTH", Menus.mms_audio_occlusion_strength);
                 Menus.mms_directional_warnings = ModPrefs.GetBool("MP_PM_DIRECTIONAL_WARNINGS", Menus.mms_directional_warnings);
-                Menus.mms_loadout_hotkeys = ModPrefs.GetBool("MP_PM_LOADOUT_HOTKEYS", Menus.mms_loadout_hotkeys);
+                Menus.mms_loadout_hotkeys = ModPrefs.GetInt("MP_PM_LOADOUT_HOTKEYS2", Menus.mms_loadout_hotkeys);
 
                 MPLoadouts.Loadouts[0].weapons[0] = (WeaponType)ModPrefs.GetInt("MP_PM_LOADOUT_BOMBER1_W1", (int)MPLoadouts.Loadouts[0].weapons[0]);
                 MPLoadouts.Loadouts[0].missiles[0] = (MissileType)ModPrefs.GetInt("MP_PM_LOADOUT_BOMBER1_M1", (int)MPLoadouts.Loadouts[0].missiles[0]);
@@ -336,7 +336,7 @@ namespace GameMod {
             ModPrefs.SetBool("MP_PM_SHOWFRAMERATE", Menus.mms_show_framerate);
             ModPrefs.SetInt("MP_PM_AUDIO_OCCLUSION_STRENGTH", Menus.mms_audio_occlusion_strength);
             ModPrefs.SetBool("MP_PM_DIRECTIONAL_WARNINGS", Menus.mms_directional_warnings);
-            ModPrefs.SetBool("MP_PM_LOADOUT_HOTKEYS", Menus.mms_loadout_hotkeys);
+            ModPrefs.SetInt("MP_PM_LOADOUT_HOTKEYS2", Menus.mms_loadout_hotkeys);
             ModPrefs.SetInt("MP_PM_LOADOUT_BOMBER1_W1", (int)MPLoadouts.Loadouts[0].weapons[0]);
             ModPrefs.SetInt("MP_PM_LOADOUT_BOMBER1_M1", (int)MPLoadouts.Loadouts[0].missiles[0]);
             ModPrefs.SetInt("MP_PM_LOADOUT_BOMBER1_M2", (int)MPLoadouts.Loadouts[0].missiles[1]);

--- a/GameMod/MPSoundExt.cs
+++ b/GameMod/MPSoundExt.cs
@@ -24,6 +24,7 @@ namespace GameMod
     public static class MPSoundExt
     {
         //public static AssetBundle ab;
+        public static GameObject[] m_a_object = new GameObject[512];
         public static AudioSource[] m_a_source = new AudioSource[512];
         public static AudioLowPassFilter[] m_a_filter = new AudioLowPassFilter[512];
     }
@@ -84,4 +85,97 @@ namespace GameMod
             }
         }
     }*/
+
+    /*
+     * *************************************************
+     * LOOPED SOUND PERFORMANCE OPTIMIZATIONS BEGIN HERE
+     * *************************************************
+     */
+
+    /* I think this one is single player only? May re-enable. It was a copy of the one for AddEnergyDefault
+    // Increases the loop wait time for the energy center sounds. There is a noticeable performance hit when charging.
+    [HarmonyPatch(typeof(Player), "AddWeakEnergy")]
+    internal class MPSoundExt_Player_AddWeakEnergy
+    */
+
+    // Increases the loop wait time for the energy center sounds. There is a noticeable performance hit when charging.
+    [HarmonyPatch(typeof(Player), "AddEnergyDefault")]
+    internal class MPSoundExt_Player_AddEnergyDefault
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            bool state = false;
+            foreach (var code in codes)
+            {
+                if (!state && code.opcode == OpCodes.Ldc_R4 && (float)code.operand == 0.1f)
+                {
+                    code.operand = 0.5f;
+                    state = true;
+                }
+                yield return code;
+            }
+        }
+    }
+
+    // Uses an unused bool field "m_one_time" in TriggerEnergy to cause it to only activate every second frame with a double energy payload from stock.
+    // Shouldn't strictly be necessary but apparently the energy center causes a lot of activity simultaneously and this *should* cut that
+    // in half with no gameplay side-effect. This could have been done faster (but a little less efficiently) with a prefix probably.
+    [HarmonyPatch(typeof(TriggerEnergy), "OnTriggerStay")]
+    internal class MPSoundExt_TriggerEnergy_OnTriggerStay
+    {
+        public static IEnumerable<CodeInstruction> Transpiler(ILGenerator ilGen, IEnumerable<CodeInstruction> codes)
+        {
+            bool state = false;
+            Label a = ilGen.DefineLabel();
+
+            foreach (var code in codes)
+            {
+                if (!state)
+                {
+                    state = true; // only run once
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(TriggerEnergy), "m_one_time"));
+                    yield return new CodeInstruction(OpCodes.Brtrue, a); // if true, run the original actual method
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_1);
+                    yield return new CodeInstruction(OpCodes.Stfld, AccessTools.Field(typeof(TriggerEnergy), "m_one_time"));
+                    yield return new CodeInstruction(OpCodes.Ret); // if false above, this exits the method early after setting m_one_time to true
+                    CodeInstruction after = new CodeInstruction(OpCodes.Ldarg_0);
+                    after.labels.Add(a);
+                    yield return after; // "brtrue" jumps here if m_one_time is true, sets it to false, and continues the method
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_0);
+                    yield return new CodeInstruction(OpCodes.Stfld, AccessTools.Field(typeof(TriggerEnergy), "m_one_time"));
+                }
+
+                if (code.opcode == OpCodes.Ldc_R4 && (float)code.operand == 15f)
+                {
+                    code.operand = 30f; // double the energy recharge payout since we halved the active recharge frames
+                }
+
+                yield return code;
+            }
+        }
+    }
+
+    /* ====== This needs to be tested properly and re-enabled in a future version - right now it works, but has not been run through the wringer, so it's commented out for now
+    
+    // slightly reduces the maximum number of player damage sound effects happening per second from 25-40 *per type* down to ~20.
+    // Lightens the load a bit caused by extra physics linecasts in heavy games when something like Flak is pelting multiple
+    // targets simultaneously.
+    [HarmonyPatch(typeof(PlayerShip), "RpcApplyDamageEffects")]
+    internal class MPSoundExt_PlayerShip_RpcApplyDamageEffects
+    {
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            foreach (var code in codes)
+            {
+                if (code.opcode == OpCodes.Ldc_R4 && ((float)code.operand == 0.025f || (float)code.operand == 0.04f))
+                {
+                    code.operand = 0.05f;   // *** THIS NEEDS TO BE FINE-TUNED AND TESTED THOROUGHLY to make sure there are still enough damage cues available that no one gets blindsided
+                }
+                yield return code;
+            }
+        }
+    }
+    */
 }

--- a/GameMod/MPSoundOcclusion.cs
+++ b/GameMod/MPSoundOcclusion.cs
@@ -7,7 +7,7 @@ using System.Reflection.Emit;
 namespace GameMod
 {
 	public static class MPSoundOcclusion
-    {	
+    {
 		//                                    N/A   LOW     MED     STRONG			
 		public static float[] MAXDISTS =    { 0f,   110f,   100f,   95f };    // xtra strong 85f
 		public static float[] BOOSTS =      { 0f,   0.10f,  0.15f,  0.20f };  // xtra strong 0.25f
@@ -17,6 +17,49 @@ namespace GameMod
 
 		// Change this at your peril, gotta recalculate the curves if you do
 		public const float MINDIST = 15f;
+
+		public static float CutoffFreq;
+		public static float BoostAmount;
+
+		public static int CueState = 0;
+		public static bool Occluded;
+
+		// an attempt to optimize the "disabled" setting for occlusion - AddFilters re-adds a new set of filters if re-enabled
+		public static void AddFilters()
+        {
+			for (int i = 0; i < 512; i++)
+            {
+				AddFilter(i);
+			}
+        }
+
+		public static void AddFilter(int i)
+		{
+			if (MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>() == null)
+			{
+				//Debug.Log("CCC creating filter " + i);
+				MPSoundExt.m_a_filter[i] = MPSoundExt.m_a_object[i].AddComponent<AudioLowPassFilter>();
+			}
+			else
+			{
+				MPSoundExt.m_a_filter[i] = MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>();
+			}
+			MPSoundExt.m_a_filter[i].cutoffFrequency = 22000f;
+			MPSoundExt.m_a_filter[i].enabled = false;
+		}
+
+		// ... while RemoveFilters takes them out completely
+		public static void RemoveFilters()
+		{
+			for (int i = 0; i < 512; i++)
+			{
+				if (MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>() != null)
+				{
+					//Debug.Log("CCC removing filter " + i);
+					Object.Destroy(MPSoundExt.m_a_filter[i]);
+				}
+			}
+		}
 	}
 
 	[HarmonyPatch(typeof(UnityAudio), "CreateAudioSourceAndObject")]
@@ -28,18 +71,13 @@ namespace GameMod
 
 			if (___m_a_object != null)
 			{
+				MPSoundExt.m_a_object[i] = ___m_a_object[i];
 				MPSoundExt.m_a_source[i] = ___m_a_object[i].GetComponent<AudioSource>();
-				if (___m_a_object[i].GetComponent<AudioLowPassFilter>() == null)
+
+				if (Menus.mms_audio_occlusion_strength != 0)
 				{
-					MPSoundExt.m_a_filter[i] = ___m_a_object[i].AddComponent<AudioLowPassFilter>();
+					MPSoundOcclusion.AddFilter(i);
 				}
-				else
-				{
-					MPSoundExt.m_a_filter[i] = ___m_a_object[i].GetComponent<AudioLowPassFilter>();
-					// this *shouldn't* happen but who knows with Overload
-				}
-				MPSoundExt.m_a_filter[i].cutoffFrequency = 22000f;
-				MPSoundExt.m_a_filter[i].enabled = false;
 			}
 		}
 	}
@@ -57,6 +95,48 @@ namespace GameMod
 		}
 	}
 
+	// Sets an int to track state for use with Occlusion in the Cue play commands since they can fire off several layers simultaneously.
+	// Previously this was resulting in several Linecasts from the same position. Should make things more efficient by allowing
+	// the PlaySound method to only do the check once for each cue.
+	// Needs to patch PlayCue2D, PlayCuePos, and PlayThunderboltFire, and all of it manually. See the next method.
+	public class MPSoundOcclusion_SFXCueManager_PlayCuePatch
+	{
+		public static void Prefix()
+		{
+			MPSoundOcclusion.CueState = 1;
+		}
+
+		public static void Postfix()
+		{
+			MPSoundOcclusion.CueState = 0;
+		}
+	}
+
+	// This whole nonsense is because SXFCueManager is a static class with a static constructor. All sorts of fun breakage
+	// using the regular patch method because the constructor ends up calling too early and there's nothing you can do
+	// to prevent it. You need to patch waaaaay at the end of the process and this seems to be the only way to force it to
+	// do this, as recommended by the Harmony devs on Discord.
+	[HarmonyPatch(typeof(PilotManager), "Initialize")]
+	class MPSoundOcclusion_PilotManager_Initialize
+	{
+		static void Postfix()
+        {
+			var harmony = new Harmony("olmod.postpatcher");
+
+			var orig1 = typeof(SFXCueManager).GetMethod("PlayCue2D");
+			var orig2 = typeof(SFXCueManager).GetMethod("PlayCuePos");
+			var orig3 = typeof(SFXCueManager).GetMethod("PlayThunderboltFire");
+
+			var prefix = typeof(MPSoundOcclusion_SFXCueManager_PlayCuePatch).GetMethod("Prefix");
+			var postfix = typeof(MPSoundOcclusion_SFXCueManager_PlayCuePatch).GetMethod("Postfix");
+
+			harmony.Patch(orig1, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+			harmony.Patch(orig2, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+			harmony.Patch(orig3, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+		}
+	}
+
+	// Main logic starts happening here
 	[HarmonyPatch(typeof(UnityAudio), "PlaySound")]
 	internal class MPSoundOcclusion_UnityAudio_PlaySound
 	{
@@ -76,64 +156,74 @@ namespace GameMod
 		}
 
 		static void Postfix(int __result, Vector3 pos3d)
-		{	
-			if (__result != -1)
+		{
+			Debug.Log("CCC setting is " + Menus.mms_audio_occlusion_strength);
+			if (__result != -1) // if -1 then we ran out of audio slots, skip the whole thing
 			{
+				// If pos3d == Vector3.zero, then it's almost without a doubt a 2D cue on the local client. It's beyond infeasible that sound could accidentally come from *exactly* this point.
+				// If it ever does, well then you get 1 glitched cue and you should have bought a lottery ticket.
 				if (Menus.mms_audio_occlusion_strength != 0)
 				{
-					if ((!MPObserver.Enabled || MPObserver.ObservedPlayer != null) && !GameplayManager.IsDedicatedServer()) // last check probably not necessary but whatever
+					if (pos3d == Vector3.zero)
 					{
-						RaycastHit ray1;
-
-						Vector3 shipPos = GameManager.m_player_ship.transform.localPosition;
-
-						// If pos3d = Vector3.zero, then it's almost without a doubt a 2D cue on the local client. It's beyond infeasible that sound could accidentally come from *exactly* this point.
-						// If it ever does, well then you get 1 glitched cue and you should have bought a lottery ticket.
-						if (pos3d != Vector3.zero && Physics.Linecast(pos3d, shipPos, out ray1, 67256320)) // check line-of-sight to sound source.
+						MPSoundOcclusion.Occluded = false;
+					}
+					else
+					{
+						if ((!MPObserver.Enabled || MPObserver.ObservedPlayer != null) && !GameplayManager.IsDedicatedServer()) // last check probably not necessary but whatever
 						{
-							// we don't have line-of-sight
-							// This is the "Tier 3" approach, taking both distance to target and thickness of obstruction into account
+							// if we're mid-cue there's multiple sounds being played from the same location - use the previous Linecast calculations for efficiency
+							if (MPSoundOcclusion.CueState < 2)
+							{
+								Vector3 shipPos = GameManager.m_player_ship.transform.localPosition;
 
-							//Debug.Log("CCC occlusion factor " + Menus.mms_audio_occlusion_strength);
+								RaycastHit ray1;
+								if (Physics.Linecast(pos3d, shipPos, out ray1, 67256320))
+								{
+									// we don't have line-of-sight
+									// This is the "Tier 3" approach, taking both distance to target and thickness of obstruction into account
+									RaycastHit ray2;
+									Physics.Linecast(shipPos, pos3d, out ray2, 67256320);
 
-							float maxdist = MPSoundOcclusion.MAXDISTS[Menus.mms_audio_occlusion_strength];
-							float cutoff = MPSoundOcclusion.CUTOFFS[Menus.mms_audio_occlusion_strength];
-							float lowfreq = MPSoundOcclusion.LOWFREQS[Menus.mms_audio_occlusion_strength];
-							float boost = MPSoundOcclusion.BOOSTS[Menus.mms_audio_occlusion_strength];
+									float maxdist = MPSoundOcclusion.MAXDISTS[Menus.mms_audio_occlusion_strength];
+									float cutoff = MPSoundOcclusion.CUTOFFS[Menus.mms_audio_occlusion_strength];
+									float lowfreq = MPSoundOcclusion.LOWFREQS[Menus.mms_audio_occlusion_strength];
+									float boost = MPSoundOcclusion.BOOSTS[Menus.mms_audio_occlusion_strength];
 
-							float p2pDist = Vector3.Distance(pos3d, shipPos); // point to point distance
-							RaycastHit ray2;
-							Physics.Linecast(shipPos, pos3d, out ray2, 67256320);
-							float thick = Mathf.Clamp(p2pDist - ray1.distance - ray2.distance, 1f, maxdist); // how thick the obstruction is, clamped
-							p2pDist = Mathf.Clamp(p2pDist, MPSoundOcclusion.MINDIST, maxdist); // clamp the p2pDist value
-							float factor = (maxdist - (0.6f * thick + 0.4f * p2pDist)) / (maxdist);
+									float p2pDist = Vector3.Distance(pos3d, shipPos); // point to point distance
 
-							MPSoundExt.m_a_filter[__result].cutoffFrequency = lowfreq + (cutoff * factor * factor); // exponential curve
+									float thick = Mathf.Clamp(p2pDist - ray1.distance - ray2.distance, 1f, maxdist); // how thick the obstruction is, clamped
+									p2pDist = Mathf.Clamp(p2pDist, MPSoundOcclusion.MINDIST, maxdist); // clamp the p2pDist value
+									float factor = (maxdist - (0.6f * thick + 0.4f * p2pDist)) / (maxdist);
 
-							//Debug.Log("CCC playing occluded, factor " + factor);
-							//Debug.Log("CCC playing occluded, original volume " + MPSoundOcclusion.m_a_source[__result].volume);
-
-							MPSoundExt.m_a_source[__result].volume = MPSoundExt.m_a_source[__result].volume + boost * (0.85f - factor); // slight boost to volume as range increases to counter the HF rolloff
-							MPSoundExt.m_a_filter[__result].enabled = true;
-
-							//Debug.Log("CCC playing occluded, new volume " + MPSoundOcclusion.m_a_source[__result].volume);
-							//Debug.Log("CCC playing occluded, distance " + p2pDist +", thickness " + thick + ", factor is " + factor + ", cutoff frequency is " + MPSoundOcclusion.m_a_filter[__result].cutoffFrequency);
-						}
-						else
-						{
-							// we have line-of-sight, restore the normal filter
-							MPSoundExt.m_a_filter[__result].cutoffFrequency = 22000f;
-							MPSoundExt.m_a_filter[__result].enabled = false;
+									MPSoundOcclusion.CutoffFreq = lowfreq + (cutoff * factor * factor); // exponential curve
+									MPSoundOcclusion.BoostAmount = boost * (0.85f - factor);
+									MPSoundOcclusion.Occluded = true;
+								}
+								else
+								{
+									MPSoundOcclusion.Occluded = false;
+								}
+							}
+							if (MPSoundOcclusion.CueState == 1) // we're in a multicue, pause calculations
+							{
+								MPSoundOcclusion.CueState = 2;
+							}
 						}
 					}
+					if (MPSoundOcclusion.Occluded)
+					{
+						MPSoundExt.m_a_filter[__result].cutoffFrequency = MPSoundOcclusion.CutoffFreq;
+						MPSoundExt.m_a_source[__result].volume = MPSoundExt.m_a_source[__result].volume + MPSoundOcclusion.BoostAmount; // slight boost to volume as range increases to counter the HF rolloff
+						MPSoundExt.m_a_filter[__result].enabled = true;
+					}
+					else
+					{
+						// restore the normal filter
+						MPSoundExt.m_a_filter[__result].cutoffFrequency = 22000f;
+						MPSoundExt.m_a_filter[__result].enabled = false;
+					}
 				}
-				else
-                {
-					// restore the filter since we're disabled and they may have been set previously
-					MPSoundExt.m_a_filter[__result].cutoffFrequency = 22000f;
-					MPSoundExt.m_a_filter[__result].enabled = false;
-				}
-
 				MPSoundExt.m_a_source[__result].Play();  // Nop'd out in the transpiler
 			}
 		}

--- a/GameMod/MPSoundOcclusion.cs
+++ b/GameMod/MPSoundOcclusion.cs
@@ -157,7 +157,6 @@ namespace GameMod
 
         static void Postfix(int __result, Vector3 pos3d)
         {
-            Debug.Log("CCC setting is " + Menus.mms_audio_occlusion_strength);
             if (__result != -1) // if -1 then we ran out of audio slots, skip the whole thing
             {
                 // If pos3d == Vector3.zero, then it's almost without a doubt a 2D cue on the local client. It's beyond infeasible that sound could accidentally come from *exactly* this point.

--- a/GameMod/MPSoundOcclusion.cs
+++ b/GameMod/MPSoundOcclusion.cs
@@ -6,226 +6,226 @@ using System.Reflection.Emit;
 
 namespace GameMod
 {
-	public static class MPSoundOcclusion
+    public static class MPSoundOcclusion
     {
-		//                                    N/A   LOW     MED     STRONG			
-		public static float[] MAXDISTS =    { 0f,   110f,   100f,   95f };    // xtra strong 85f
-		public static float[] BOOSTS =      { 0f,   0.10f,  0.15f,  0.20f };  // xtra strong 0.25f
-		public static float[] LOWFREQS =    { 0f,   950f,   800f,   500f };   // xtra strong 500f
-		public static float[] CUTOFFS =     { 0f,   9000f,  9500f,  10000f }; // xtra strong 10500f
-		// actual cutoff starting point is currently targetted at ~7khz since we are clamping to 15 units minimum distance below
+        //                                    N/A   LOW     MED     STRONG			
+        public static float[] MAXDISTS =    { 0f,   110f,   100f,   95f };    // xtra strong 85f
+        public static float[] BOOSTS =      { 0f,   0.10f,  0.15f,  0.20f };  // xtra strong 0.25f
+        public static float[] LOWFREQS =    { 0f,   950f,   800f,   500f };   // xtra strong 500f
+        public static float[] CUTOFFS =     { 0f,   9000f,  9500f,  10000f }; // xtra strong 10500f
+        // actual cutoff starting point is currently targetted at ~7khz since we are clamping to 15 units minimum distance below
 
-		// Change this at your peril, gotta recalculate the curves if you do
-		public const float MINDIST = 15f;
+        // Change this at your peril, gotta recalculate the curves if you do
+        public const float MINDIST = 15f;
 
-		public static float CutoffFreq;
-		public static float BoostAmount;
+        public static float CutoffFreq;
+        public static float BoostAmount;
 
-		public static int CueState = 0;
-		public static bool Occluded;
+        public static int CueState = 0;
+        public static bool Occluded;
 
-		// an attempt to optimize the "disabled" setting for occlusion - AddFilters re-adds a new set of filters if re-enabled
-		public static void AddFilters()
+        // an attempt to optimize the "disabled" setting for occlusion - AddFilters re-adds a new set of filters if re-enabled
+        public static void AddFilters()
         {
-			for (int i = 0; i < 512; i++)
+            for (int i = 0; i < 512; i++)
             {
-				AddFilter(i);
-			}
+                AddFilter(i);
+            }
         }
 
-		public static void AddFilter(int i)
-		{
-			if (MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>() == null)
-			{
-				//Debug.Log("CCC creating filter " + i);
-				MPSoundExt.m_a_filter[i] = MPSoundExt.m_a_object[i].AddComponent<AudioLowPassFilter>();
-			}
-			else
-			{
-				MPSoundExt.m_a_filter[i] = MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>();
-			}
-			MPSoundExt.m_a_filter[i].cutoffFrequency = 22000f;
-			MPSoundExt.m_a_filter[i].enabled = false;
-		}
-
-		// ... while RemoveFilters takes them out completely
-		public static void RemoveFilters()
-		{
-			for (int i = 0; i < 512; i++)
-			{
-				if (MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>() != null)
-				{
-					//Debug.Log("CCC removing filter " + i);
-					Object.Destroy(MPSoundExt.m_a_filter[i]);
-				}
-			}
-		}
-	}
-
-	[HarmonyPatch(typeof(UnityAudio), "CreateAudioSourceAndObject")]
-	internal class MPSoundOcclusion_UnityAudio_CreateAudioSourceAndObject
-	{
-		static void Postfix(ref GameObject[] ___m_a_object, int i)
+        public static void AddFilter(int i)
         {
-			//GameManager.m_audio.m_debug_sounds = true;
+            if (MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>() == null)
+            {
+                //Debug.Log("CCC creating filter " + i);
+                MPSoundExt.m_a_filter[i] = MPSoundExt.m_a_object[i].AddComponent<AudioLowPassFilter>();
+            }
+            else
+            {
+                MPSoundExt.m_a_filter[i] = MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>();
+            }
+            MPSoundExt.m_a_filter[i].cutoffFrequency = 22000f;
+            MPSoundExt.m_a_filter[i].enabled = false;
+        }
 
-			if (___m_a_object != null)
-			{
-				MPSoundExt.m_a_object[i] = ___m_a_object[i];
-				MPSoundExt.m_a_source[i] = ___m_a_object[i].GetComponent<AudioSource>();
-
-				if (Menus.mms_audio_occlusion_strength != 0)
-				{
-					MPSoundOcclusion.AddFilter(i);
-				}
-			}
-		}
-	}
-
-	[HarmonyPatch(typeof(GameplayManager), "DoneLevel")]
-	internal class MPSoundOcclusion_GameplayManager_DoneLevel
-	{
-		static void Postfix()
-		{
-			foreach (AudioLowPassFilter f in MPSoundExt.m_a_filter)
-			{
-				f.cutoffFrequency = 22000f;
-				f.enabled = false;
-			}
-		}
-	}
-
-	// Sets an int to track state for use with Occlusion in the Cue play commands since they can fire off several layers simultaneously.
-	// Previously this was resulting in several Linecasts from the same position. Should make things more efficient by allowing
-	// the PlaySound method to only do the check once for each cue.
-	// Needs to patch PlayCue2D, PlayCuePos, and PlayThunderboltFire, and all of it manually. See the next method.
-	public class MPSoundOcclusion_SFXCueManager_PlayCuePatch
-	{
-		public static void Prefix()
-		{
-			MPSoundOcclusion.CueState = 1;
-		}
-
-		public static void Postfix()
-		{
-			MPSoundOcclusion.CueState = 0;
-		}
-	}
-
-	// This whole nonsense is because SXFCueManager is a static class with a static constructor. All sorts of fun breakage
-	// using the regular patch method because the constructor ends up calling too early and there's nothing you can do
-	// to prevent it. You need to patch waaaaay at the end of the process and this seems to be the only way to force it to
-	// do this, as recommended by the Harmony devs on Discord.
-	[HarmonyPatch(typeof(PilotManager), "Initialize")]
-	class MPSoundOcclusion_PilotManager_Initialize
-	{
-		static void Postfix()
+        // ... while RemoveFilters takes them out completely
+        public static void RemoveFilters()
         {
-			var harmony = new Harmony("olmod.postpatcher");
+            for (int i = 0; i < 512; i++)
+            {
+                if (MPSoundExt.m_a_object[i].GetComponent<AudioLowPassFilter>() != null)
+                {
+                    //Debug.Log("CCC removing filter " + i);
+                    Object.Destroy(MPSoundExt.m_a_filter[i]);
+                }
+            }
+        }
+    }
 
-			var orig1 = typeof(SFXCueManager).GetMethod("PlayCue2D");
-			var orig2 = typeof(SFXCueManager).GetMethod("PlayCuePos");
-			var orig3 = typeof(SFXCueManager).GetMethod("PlayThunderboltFire");
+    [HarmonyPatch(typeof(UnityAudio), "CreateAudioSourceAndObject")]
+    internal class MPSoundOcclusion_UnityAudio_CreateAudioSourceAndObject
+    {
+        static void Postfix(ref GameObject[] ___m_a_object, int i)
+        {
+            //GameManager.m_audio.m_debug_sounds = true;
 
-			var prefix = typeof(MPSoundOcclusion_SFXCueManager_PlayCuePatch).GetMethod("Prefix");
-			var postfix = typeof(MPSoundOcclusion_SFXCueManager_PlayCuePatch).GetMethod("Postfix");
+            if (___m_a_object != null)
+            {
+                MPSoundExt.m_a_object[i] = ___m_a_object[i];
+                MPSoundExt.m_a_source[i] = ___m_a_object[i].GetComponent<AudioSource>();
 
-			harmony.Patch(orig1, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
-			harmony.Patch(orig2, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
-			harmony.Patch(orig3, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
-		}
-	}
+                if (Menus.mms_audio_occlusion_strength != 0)
+                {
+                    MPSoundOcclusion.AddFilter(i);
+                }
+            }
+        }
+    }
 
-	// Main logic starts happening here
-	[HarmonyPatch(typeof(UnityAudio), "PlaySound")]
-	internal class MPSoundOcclusion_UnityAudio_PlaySound
-	{
-		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
-		{
-			foreach (var code in codes)
-			{
-				if (code.opcode == OpCodes.Call && code.operand == AccessTools.Method(typeof(AudioSource), "Play"))
-				{
-					yield return new CodeInstruction(OpCodes.Nop);
-				}
-				else
-				{
-					yield return code;
-				}
-			}
-		}
+    [HarmonyPatch(typeof(GameplayManager), "DoneLevel")]
+    internal class MPSoundOcclusion_GameplayManager_DoneLevel
+    {
+        static void Postfix()
+        {
+            foreach (AudioLowPassFilter f in MPSoundExt.m_a_filter)
+            {
+                f.cutoffFrequency = 22000f;
+                f.enabled = false;
+            }
+        }
+    }
 
-		static void Postfix(int __result, Vector3 pos3d)
-		{
-			Debug.Log("CCC setting is " + Menus.mms_audio_occlusion_strength);
-			if (__result != -1) // if -1 then we ran out of audio slots, skip the whole thing
-			{
-				// If pos3d == Vector3.zero, then it's almost without a doubt a 2D cue on the local client. It's beyond infeasible that sound could accidentally come from *exactly* this point.
-				// If it ever does, well then you get 1 glitched cue and you should have bought a lottery ticket.
-				if (Menus.mms_audio_occlusion_strength != 0)
-				{
-					if (pos3d == Vector3.zero)
-					{
-						MPSoundOcclusion.Occluded = false;
-					}
-					else
-					{
-						if ((!MPObserver.Enabled || MPObserver.ObservedPlayer != null) && !GameplayManager.IsDedicatedServer()) // last check probably not necessary but whatever
-						{
-							// if we're mid-cue there's multiple sounds being played from the same location - use the previous Linecast calculations for efficiency
-							if (MPSoundOcclusion.CueState < 2)
-							{
-								Vector3 shipPos = GameManager.m_player_ship.transform.localPosition;
+    // Sets an int to track state for use with Occlusion in the Cue play commands since they can fire off several layers simultaneously.
+    // Previously this was resulting in several Linecasts from the same position. Should make things more efficient by allowing
+    // the PlaySound method to only do the check once for each cue.
+    // Needs to patch PlayCue2D, PlayCuePos, and PlayThunderboltFire, and all of it manually. See the next method.
+    public class MPSoundOcclusion_SFXCueManager_PlayCuePatch
+    {
+        public static void Prefix()
+        {
+            MPSoundOcclusion.CueState = 1;
+        }
 
-								RaycastHit ray1;
-								if (Physics.Linecast(pos3d, shipPos, out ray1, 67256320))
-								{
-									// we don't have line-of-sight
-									// This is the "Tier 3" approach, taking both distance to target and thickness of obstruction into account
-									RaycastHit ray2;
-									Physics.Linecast(shipPos, pos3d, out ray2, 67256320);
+        public static void Postfix()
+        {
+            MPSoundOcclusion.CueState = 0;
+        }
+    }
 
-									float maxdist = MPSoundOcclusion.MAXDISTS[Menus.mms_audio_occlusion_strength];
-									float cutoff = MPSoundOcclusion.CUTOFFS[Menus.mms_audio_occlusion_strength];
-									float lowfreq = MPSoundOcclusion.LOWFREQS[Menus.mms_audio_occlusion_strength];
-									float boost = MPSoundOcclusion.BOOSTS[Menus.mms_audio_occlusion_strength];
+    // This whole nonsense is because SXFCueManager is a static class with a static constructor. All sorts of fun breakage
+    // using the regular patch method because the constructor ends up calling too early and there's nothing you can do
+    // to prevent it. You need to patch waaaaay at the end of the process and this seems to be the only way to force it to
+    // do this, as recommended by the Harmony devs on Discord.
+    [HarmonyPatch(typeof(PilotManager), "Initialize")]
+    class MPSoundOcclusion_PilotManager_Initialize
+    {
+        static void Postfix()
+        {
+            var harmony = new Harmony("olmod.postpatcher");
 
-									float p2pDist = Vector3.Distance(pos3d, shipPos); // point to point distance
+            var orig1 = typeof(SFXCueManager).GetMethod("PlayCue2D");
+            var orig2 = typeof(SFXCueManager).GetMethod("PlayCuePos");
+            var orig3 = typeof(SFXCueManager).GetMethod("PlayThunderboltFire");
 
-									float thick = Mathf.Clamp(p2pDist - ray1.distance - ray2.distance, 1f, maxdist); // how thick the obstruction is, clamped
-									p2pDist = Mathf.Clamp(p2pDist, MPSoundOcclusion.MINDIST, maxdist); // clamp the p2pDist value
-									float factor = (maxdist - (0.6f * thick + 0.4f * p2pDist)) / (maxdist);
+            var prefix = typeof(MPSoundOcclusion_SFXCueManager_PlayCuePatch).GetMethod("Prefix");
+            var postfix = typeof(MPSoundOcclusion_SFXCueManager_PlayCuePatch).GetMethod("Postfix");
 
-									MPSoundOcclusion.CutoffFreq = lowfreq + (cutoff * factor * factor); // exponential curve
-									MPSoundOcclusion.BoostAmount = boost * (0.85f - factor);
-									MPSoundOcclusion.Occluded = true;
-								}
-								else
-								{
-									MPSoundOcclusion.Occluded = false;
-								}
-							}
-							if (MPSoundOcclusion.CueState == 1) // we're in a multicue, pause calculations
-							{
-								MPSoundOcclusion.CueState = 2;
-							}
-						}
-					}
-					if (MPSoundOcclusion.Occluded)
-					{
-						MPSoundExt.m_a_filter[__result].cutoffFrequency = MPSoundOcclusion.CutoffFreq;
-						MPSoundExt.m_a_source[__result].volume = MPSoundExt.m_a_source[__result].volume + MPSoundOcclusion.BoostAmount; // slight boost to volume as range increases to counter the HF rolloff
-						MPSoundExt.m_a_filter[__result].enabled = true;
-					}
-					else
-					{
-						// restore the normal filter
-						MPSoundExt.m_a_filter[__result].cutoffFrequency = 22000f;
-						MPSoundExt.m_a_filter[__result].enabled = false;
-					}
-				}
-				MPSoundExt.m_a_source[__result].Play();  // Nop'd out in the transpiler
-			}
-		}
-	}
+            harmony.Patch(orig1, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+            harmony.Patch(orig2, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+            harmony.Patch(orig3, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+        }
+    }
+
+    // Main logic starts happening here
+    [HarmonyPatch(typeof(UnityAudio), "PlaySound")]
+    internal class MPSoundOcclusion_UnityAudio_PlaySound
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            foreach (var code in codes)
+            {
+                if (code.opcode == OpCodes.Call && code.operand == AccessTools.Method(typeof(AudioSource), "Play"))
+                {
+                    yield return new CodeInstruction(OpCodes.Nop);
+                }
+                else
+                {
+                    yield return code;
+                }
+            }
+        }
+
+        static void Postfix(int __result, Vector3 pos3d)
+        {
+            Debug.Log("CCC setting is " + Menus.mms_audio_occlusion_strength);
+            if (__result != -1) // if -1 then we ran out of audio slots, skip the whole thing
+            {
+                // If pos3d == Vector3.zero, then it's almost without a doubt a 2D cue on the local client. It's beyond infeasible that sound could accidentally come from *exactly* this point.
+                // If it ever does, well then you get 1 glitched cue and you should have bought a lottery ticket.
+                if (Menus.mms_audio_occlusion_strength != 0)
+                {
+                    if (pos3d == Vector3.zero)
+                    {
+                        MPSoundOcclusion.Occluded = false;
+                    }
+                    else
+                    {
+                        if ((!MPObserver.Enabled || MPObserver.ObservedPlayer != null) && !GameplayManager.IsDedicatedServer()) // last check probably not necessary but whatever
+                        {
+                            // if we're mid-cue there's multiple sounds being played from the same location - use the previous Linecast calculations for efficiency
+                            if (MPSoundOcclusion.CueState < 2)
+                            {
+                                Vector3 shipPos = GameManager.m_player_ship.transform.localPosition;
+
+                                RaycastHit ray1;
+                                if (Physics.Linecast(pos3d, shipPos, out ray1, 67256320))
+                                {
+                                    // we don't have line-of-sight
+                                    // This is the "Tier 3" approach, taking both distance to target and thickness of obstruction into account
+                                    RaycastHit ray2;
+                                    Physics.Linecast(shipPos, pos3d, out ray2, 67256320);
+
+                                    float maxdist = MPSoundOcclusion.MAXDISTS[Menus.mms_audio_occlusion_strength];
+                                    float cutoff = MPSoundOcclusion.CUTOFFS[Menus.mms_audio_occlusion_strength];
+                                    float lowfreq = MPSoundOcclusion.LOWFREQS[Menus.mms_audio_occlusion_strength];
+                                    float boost = MPSoundOcclusion.BOOSTS[Menus.mms_audio_occlusion_strength];
+
+                                    float p2pDist = Vector3.Distance(pos3d, shipPos); // point to point distance
+
+                                    float thick = Mathf.Clamp(p2pDist - ray1.distance - ray2.distance, 1f, maxdist); // how thick the obstruction is, clamped
+                                    p2pDist = Mathf.Clamp(p2pDist, MPSoundOcclusion.MINDIST, maxdist); // clamp the p2pDist value
+                                    float factor = (maxdist - (0.6f * thick + 0.4f * p2pDist)) / (maxdist);
+
+                                    MPSoundOcclusion.CutoffFreq = lowfreq + (cutoff * factor * factor); // exponential curve
+                                    MPSoundOcclusion.BoostAmount = boost * (0.85f - factor);
+                                    MPSoundOcclusion.Occluded = true;
+                                }
+                                else
+                                {
+                                    MPSoundOcclusion.Occluded = false;
+                                }
+                            }
+                            if (MPSoundOcclusion.CueState == 1) // we're in a multicue, pause calculations
+                            {
+                                MPSoundOcclusion.CueState = 2;
+                            }
+                        }
+                    }
+                    if (MPSoundOcclusion.Occluded)
+                    {
+                        MPSoundExt.m_a_filter[__result].cutoffFrequency = MPSoundOcclusion.CutoffFreq;
+                        MPSoundExt.m_a_source[__result].volume = MPSoundExt.m_a_source[__result].volume + MPSoundOcclusion.BoostAmount; // slight boost to volume as range increases to counter the HF rolloff
+                        MPSoundExt.m_a_filter[__result].enabled = true;
+                    }
+                    else
+                    {
+                        // restore the normal filter
+                        MPSoundExt.m_a_filter[__result].cutoffFrequency = 22000f;
+                        MPSoundExt.m_a_filter[__result].enabled = false;
+                    }
+                }
+                MPSoundExt.m_a_source[__result].Play();  // Nop'd out in the transpiler
+            }
+        }
+    }
 }

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -70,7 +70,6 @@ namespace GameMod {
                 {
                     MPSoundOcclusion.AddFilters();
                 }
-                Debug.Log("CCC setting to " + value);
                 mms_audio_occlusion_strength_internal = value;
             }
         }

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -53,7 +53,27 @@ namespace GameMod {
             return MenuManager.GetToggleSetting(Convert.ToInt32(RearView.MPMenuManagerEnabled));
         }
 
-        public static int mms_audio_occlusion_strength { get; set; } = 0;
+        private static int mms_audio_occlusion_strength_internal = 0;
+        public static int mms_audio_occlusion_strength
+        {
+            get
+            {
+                return mms_audio_occlusion_strength_internal;
+            }
+            set
+            {
+                if (value == 0)
+                {
+                    MPSoundOcclusion.RemoveFilters();
+                }
+                else if (mms_audio_occlusion_strength_internal == 0)
+                {
+                    MPSoundOcclusion.AddFilters();
+                }
+                Debug.Log("CCC setting to " + value);
+                mms_audio_occlusion_strength_internal = value;
+            }
+        }
         public static string GetMMSAudioOcclusionStrength()
         {
             switch (mms_audio_occlusion_strength)
@@ -77,10 +97,22 @@ namespace GameMod {
             return MenuManager.GetToggleSetting(Convert.ToInt32(mms_directional_warnings));
         }
 
-        public static bool mms_loadout_hotkeys { get; set; } = true;
+        public static int mms_loadout_hotkeys { get; set; } = 1;
         public static string GetMMSLoadoutHotkeys()
         {
-            return MenuManager.GetToggleSetting(Convert.ToInt32(mms_loadout_hotkeys));
+            switch (mms_loadout_hotkeys)
+            {
+                case 0:
+                    return "OFF";
+                case 1:
+                    return "PRIMARY SELECT KEYS";
+                case 2:
+                    return "SEPARATE PRIMARIES";
+                case 3:
+                    return "NUMBER KEYS 1-4";
+                default:
+                    return "UNKNOWN";
+            }
         }
 
         public static string GetMMSAlwaysCloaked()
@@ -655,7 +687,7 @@ namespace GameMod {
                     position.y += 52f;
                     __instance.SelectAndDrawStringOptionItem(Loc.LS("PROFANITY FILTER"), position, 8, DisableProfanityFilter.profanity_filter ? "ON" : "OFF", Loc.LS(""));
                     position.y += 52f;
-                    __instance.SelectAndDrawStringOptionItem(Loc.LS("ENABLE LOADOUT SELECTION HOTKEYS"), position, 9, Menus.GetMMSLoadoutHotkeys(), Loc.LS("WEAPON SELECTION HOTKEYS WILL QUICK-SWAP BETWEEN LOADOUTS"));
+                    __instance.SelectAndDrawStringOptionItem(Loc.LS("LOADOUT SELECTION HOTKEYS"), position, 9, Menus.GetMMSLoadoutHotkeys(), Loc.LS("WEAPON SELECTION HOTKEYS WILL QUICK-SWAP BETWEEN LOADOUTS"));
                     position.y += 68f;
                     __instance.SelectAndDrawItem(Loc.LS("QUICK CHAT"), position, 1, false, 1f, 0.75f);
                     break;
@@ -908,7 +940,11 @@ namespace GameMod {
                                         MenuManager.PlaySelectSound(1f);
                                         break;
                                     case 9:
-                                        Menus.mms_loadout_hotkeys = !Menus.mms_loadout_hotkeys;
+                                        Menus.mms_loadout_hotkeys = (Menus.mms_loadout_hotkeys + UIManager.m_select_dir) % 4;
+                                        if (Menus.mms_loadout_hotkeys < 0)
+                                        {
+                                            Menus.mms_loadout_hotkeys = 3;
+                                        }
                                         MenuManager.PlaySelectSound(1f);
                                         break;
                                 }


### PR DESCRIPTION
Many things.
1 - Slightly updated menu for loadout selection hotkeys (there's 3 choices now + off).
2 - Energy center optimizations (half the updates, only 20% of the sound cues)
3 - Multisound SFXCues now only calculate occlusion linecasts for the first cue and reuse it for the others.
4 - Directional homing sounds now only calculate their position when the sound actually plays rather than -every frame for every projectile- (oops).
5 - Fully removes the AudioLowPassFilter objects when AudioOcclusion is turned off and adds them back in if it's re-enabled.

Fixed to merge properly this time.