### PR TITLE
Reduce "Player Joining" timeout from 60s to 5s

### DIFF
--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -160,6 +160,7 @@
     <Compile Include="MPOpponentCockpits.cs" />
     <Compile Include="MPPickupCheck.cs" />
     <Compile Include="MPPrimaries.cs" />
+    <Compile Include="MPReduceJoinTimeout.cs" />
     <Compile Include="MPRespawn.cs" />
     <Compile Include="MPScoreboards.cs" />
     <Compile Include="MPServerBrowser.cs" />

--- a/GameMod/MPReduceJoinTimeout.cs
+++ b/GameMod/MPReduceJoinTimeout.cs
@@ -1,0 +1,43 @@
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.Networking.NetworkSystem;
+
+
+namespace GameMod
+{
+    // change the 60 second "Player Joining" timeout to 5 seconds
+    [HarmonyPatch]
+    class MPReduceJoinTimeout
+    {
+        private static MethodBase TargetMethod()
+        {
+            return typeof(NetworkMatch).GetNestedType("HostPlayerMatchmakerInfo", AccessTools.all).GetMethod("GetStatus");
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            int state = 0;
+            foreach (var code in codes)
+            {
+                if (state == 0) {
+                    if (code.opcode == OpCodes.Ldc_R8 && (double)code.operand == 60) {
+                        state = 1;
+                        yield return new CodeInstruction(OpCodes.Ldc_R8, 5.0);
+                    } else {
+                        yield return code;
+                    }
+                } else {
+                    yield return code;
+                }
+            }
+            if (state != 1) {
+                Debug.LogFormat("MPReduceJoinTimeout: transpiler failed at state {0}",state);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sometimes, we see the server hang in the "Player Joining" phase for a whole minute, where other players are unable to join. Usually, the "Player Joining" state is shown for fractions of a second, so reducing this timeout (it is probably a remnant from the original matchmaking system) to just 5 seconds should be still more than enough.