### PR TITLE
Explicitly set the order of the transpilers to `DrawMpMatchSetup()`

### DIFF
--- a/GameMod/MPInternet.cs
+++ b/GameMod/MPInternet.cs
@@ -287,6 +287,7 @@ namespace GameMod {
             return !Core.GameMod.HasInternetMatch();
         }
 
+        [HarmonyPriority(Priority.Normal - 5)] // set global order of transpilers for this function
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             var mpInternet_PasswordFieldName_Method = AccessTools.Method(typeof(MPInternet), "PasswordFieldName");
@@ -311,6 +312,7 @@ namespace GameMod {
             return Core.GameMod.HasInternetMatch();
         }
 
+        [HarmonyPriority(Priority.Normal - 6)] // set global order of transpilers for this function
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             int state = 0; // 0 before olmod text, 1 waiting for position reset, 2 after position reset

--- a/GameMod/MPJoinInProgress.cs
+++ b/GameMod/MPJoinInProgress.cs
@@ -656,6 +656,7 @@ namespace GameMod {
             uie.DrawMenuToolTip(position + Vector2.up * 40f);
         }
 
+        [HarmonyPriority(Priority.Normal - 7)] // set global order of transpilers for this function
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             var jipMatchSetup_DrawMpMatchCreateOpen_Method = AccessTools.Method(typeof(JIPMatchSetup), "DrawMpMatchCreateOpen");

--- a/GameMod/MPMatchPresets.cs
+++ b/GameMod/MPMatchPresets.cs
@@ -307,6 +307,7 @@ namespace GameMod
             {
             }
 
+            [HarmonyPriority(Priority.Normal - 1)] // set global order of transpilers for this function
             private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
             {
                 int state = 0;

--- a/GameMod/MPModifiers.cs
+++ b/GameMod/MPModifiers.cs
@@ -93,6 +93,7 @@ namespace GameMod
                 uie.SelectAndDrawItem("ALLOWED MODIFIERS", position, 8, false, 1f, 0.75f);
             }
 
+            [HarmonyPriority(Priority.Normal - 2)] // set global order of transpilers for this function
             private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
             {
                 int state = 0;

--- a/GameMod/MPServerBrowser.cs
+++ b/GameMod/MPServerBrowser.cs
@@ -982,6 +982,7 @@ namespace GameMod
             position.y += 62f;
         }
 
+        [HarmonyPriority(Priority.Normal - 3)] // set global order of transpilers for this function
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             var mpServerBrowser_UIElement_DrawMpMatchSetup_DrawMatchNotes_Method = AccessTools.Method(typeof(MPServerBrowser_UIElement_DrawMpMatchSetup), "DrawMatchNotes");

--- a/GameMod/MPSuddenDeath.cs
+++ b/GameMod/MPSuddenDeath.cs
@@ -139,6 +139,7 @@ namespace GameMod
             position.y += 62f;
         }
 
+        [HarmonyPriority(Priority.Normal - 4)] // set global order of transpilers for this function
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             var powerupFound = false;

--- a/GameMod/MPTeams.cs
+++ b/GameMod/MPTeams.cs
@@ -994,6 +994,7 @@ namespace GameMod
     [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
     class MPTeamsMenuDraw
     {
+        [HarmonyPriority(Priority.Normal - 8)] // set global order of transpilers for this function
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> cs)
         {
             var vector2_y_Field = AccessTools.Field(typeof(Vector2), "y");

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -313,6 +313,7 @@ namespace GameMod {
             position.x += 300f;
         }
 
+        [HarmonyPriority(Priority.Normal - 9)] // set global order of transpilers for this function
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             int state = 0;
@@ -629,6 +630,7 @@ namespace GameMod {
     class Menus_UIElement_DrawMpMatchSetup_ScaleRespawnTime
     {
         // Change fade parameter on respawn slider from MenuManager.mms_mode == MatchMode.MONSTERBALL to Menus.mms_scale_respawn
+        [HarmonyPriority(Priority.Normal - 10)] // set global order of transpilers for this function
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             int state = 0;


### PR DESCRIPTION
This patch fixes Multiplayer "Advanced Settings" menu on linux builds.

If a function is patched multiple times, the order the patches are applied is not well-defined - it depends on the order the patch methods are found in the assembly, which may differ for different build systems.

This patch explicitly applies the order by specifying `[Harmony.Priority]` annotations to each of the total of 10(!) transpilers to `DrawMpMatchSetup()`. Note that a higher number means the transpiler is applied earlier, so I use the `Priority.Normal -n` scheme to denote the n-th place in the series.

The order explicitly set here matches the order the transpilers are applied in the windows build, so it has no further effect on the official olmod binaries which are distributed.