### PR TITLE
Forgot to check if the client can handle a CTFJoinUpdate message before sending.

### DIFF
--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -170,10 +170,20 @@ namespace GameMod
         // Action for input binding "Toggle Loadout Primary"
         public static void ToggleLoadoutPrimary(Player player)
         {
-            var nextWeapon = WeaponType.NUM;
-            if (NetworkMatch.m_force_loadout == 1 && NetworkMatch.m_force_w2 != WeaponType.NUM)
+            if (Menus.mms_classic_spawns)
+                return;
+
+                var nextWeapon = WeaponType.NUM;
+            if (NetworkMatch.m_force_loadout == 1)
             {
-                nextWeapon = NetworkMatch.m_force_w1 == player.m_weapon_type ? NetworkMatch.m_force_w2 : NetworkMatch.m_force_w1;
+                if (NetworkMatch.m_force_w2 == WeaponType.NUM)
+                {
+                    nextWeapon = NetworkMatch.m_force_w1;
+                }
+                else
+                {
+                    nextWeapon = NetworkMatch.m_force_w1 == player.m_weapon_type ? NetworkMatch.m_force_w2 : NetworkMatch.m_force_w1;
+                }
             }
             else
             {

--- a/GameMod/MPTweaks.cs
+++ b/GameMod/MPTweaks.cs
@@ -286,7 +286,7 @@ namespace GameMod {
             caps.Add("ModVersion", OlmodVersion.FullVersionString);
             caps.Add("Modded", Core.GameMod.Modded ? "1" : "0");
             caps.Add("ModsLoaded", Core.GameMod.ModsLoaded);
-            caps.Add("SupportsTweaks", "changeteam,deathreview,sniper,jip,nocompress_0_3_6,customloadouts,damagenumbers" + (MPAudioTaunts.AClient.active ? ",audiotaunts":""));
+            caps.Add("SupportsTweaks", "changeteam,deathreview,sniper,jip,nocompress_0_3_6,customloadouts,damagenumbers,ctfjoin" + (MPAudioTaunts.AClient.active ? ",audiotaunts":""));
             caps.Add("ModPrivateData", "1");
             caps.Add("ClassicWeaponSpawns", "1");
             caps.Add("NetVersion", MPTweaks.NET_VERSION.ToString());


### PR DESCRIPTION
Also fixes a bug that occurs when Classic Spawns is used with the Toggle Loadout Primary control.