### PR TITLE
Improve chat commands, especially player selection and tracker update on /EXTEND.

### DIFF
--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -670,6 +670,7 @@ namespace GameMod {
                 matchStartInfo.SetValue(hai, now);
 
                 ReturnTo(String.Format("manual {0} request by {1}: {2} seconds",op,senderEntry.name,seconds));
+                ServerLobbyStatus.SendToTracker(); // update the tracker
             } else {
                 Debug.LogFormat("{0} request via chat command ignored: no HostActiveMatchInfo",op);
                 ReturnToSender(String.Format("{0} rejected: no HostActiveMatchInfo",op));

--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -669,8 +669,7 @@ namespace GameMod {
                 matchTimeOutInfo.SetValue(hai, offset);
                 matchStartInfo.SetValue(hai, now);
 
-                ReturnTo(String.Format("manual {0} request by {1}: {2} seconds",op,senderEntry.name,offset.TotalSeconds));
-                //ReturnToSender(String.Format("Server's timeout is now {0}",startTime));
+                ReturnTo(String.Format("manual {0} request by {1}: {2} seconds",op,senderEntry.name,seconds));
             } else {
                 Debug.LogFormat("{0} request via chat command ignored: no HostActiveMatchInfo",op);
                 ReturnToSender(String.Format("{0} rejected: no HostActiveMatchInfo",op));

--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -243,7 +243,7 @@ namespace GameMod {
             } else if (cmdName == "EX" || cmdName == "EXTEND") {
                 cmd = Command.Extend;
                 needAuth = true;
-            } else if (cmdName == "STATUS") {
+            } else if (cmdName == "I" || cmdName == "INFO" || cmdName == "STATUS") {
                 cmd = Command.Status;
             } else if (cmdName == "SAY" || cmdName == "CHAT") {
                 cmd = Command.Say;

--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -772,33 +772,38 @@ namespace GameMod {
         // Execute LISTPLAYERS command
         public bool DoListPlayers()
         {
-            int argId = -1;
+            int argIdLow = -1;
+            int argIdHigh = -1;
             int cnt = 0;
 
             if (!String.IsNullOrEmpty(arg)) {
-                if (!int.TryParse(arg, NumberStyles.Number, CultureInfo.InvariantCulture, out argId)) {
-                    argId = -1;
+                string[] parts = arg.Split(' ');
+                if (parts.Length > 0) {
+                    if (!int.TryParse(parts[0], NumberStyles.Number, CultureInfo.InvariantCulture, out argIdLow)) {
+                        argIdLow = -1;
+                    }
+                }
+                if (parts.Length > 1) {
+                    if (!int.TryParse(parts[1], NumberStyles.Number, CultureInfo.InvariantCulture, out argIdHigh)) {
+                        argIdHigh = -1;
+                    }
+                }
+                if (argIdHigh < 0) {
+                    argIdHigh = argIdLow;
                 }
             }
 
-            if (argId < 0) {
-                for (int i = 0; i < NetworkServer.connections.Count; i++) {
+            for (int i = 0; i < NetworkServer.connections.Count; i++) {
+                if (argIdLow < 0 || (i >= argIdLow && i <= argIdHigh)) {
                     string name = FindPlayerNameForConnection(i, inLobby);
                     if (!String.IsNullOrEmpty(name)) {
                         ReturnToSender(String.Format("{0}: {1}",i,name));
                         cnt++;
                     }
                 }
-                if (cnt < 1) {
-                    ReturnToSender("LISTPLAYERS: no players found");
-                }
-            } else {
-                string name = FindPlayerNameForConnection(argId, inLobby);
-                if (!String.IsNullOrEmpty(name)) {
-                    ReturnToSender(String.Format("{0}: {1}",argId,name));
-                } else {
-                    ReturnToSender(String.Format("LISTPLAYERS: no player with connection id {0}",argId));
-                }
+            }
+            if (cnt < 1) {
+                ReturnToSender("LISTPLAYERS: no players found");
             }
             return false;
         }

--- a/GameMod/MPChatCommands.cs
+++ b/GameMod/MPChatCommands.cs
@@ -131,6 +131,7 @@ namespace GameMod {
             Say,
             Test,
             SwitchTeam,
+            ListPlayers,
         }
 
         // properties:
@@ -251,6 +252,8 @@ namespace GameMod {
                 cmd = Command.Test;
             } else if (cmdName == "ST" || cmdName == "SWITCHTEAM") {
                 cmd = Command.SwitchTeam;
+            } else if (cmdName == "LP" || cmdName == "LISTPLAYERS") {
+                cmd = Command.ListPlayers;
             }
         }
 
@@ -342,6 +345,9 @@ namespace GameMod {
                     break;
                 case Command.SwitchTeam:
                     result = DoSwitchTeam();
+                    break;
+                case Command.ListPlayers:
+                    result = DoListPlayers();
                     break;
                 default:
                     Debug.LogFormat("CHATCMD {0}: {1} {2} was not handled by server", cmd, cmdName, arg);
@@ -763,6 +769,40 @@ namespace GameMod {
             return false;
         }
 
+        // Execute LISTPLAYERS command
+        public bool DoListPlayers()
+        {
+            int argId = -1;
+            int cnt = 0;
+
+            if (!String.IsNullOrEmpty(arg)) {
+                if (!int.TryParse(arg, NumberStyles.Number, CultureInfo.InvariantCulture, out argId)) {
+                    argId = -1;
+                }
+            }
+
+            if (argId < 0) {
+                for (int i = 0; i < NetworkServer.connections.Count; i++) {
+                    string name = FindPlayerNameForConnection(i, inLobby);
+                    if (!String.IsNullOrEmpty(name)) {
+                        ReturnToSender(String.Format("{0}: {1}",i,name));
+                        cnt++;
+                    }
+                }
+                if (cnt < 1) {
+                    ReturnToSender("LISTPLAYERS: no players found");
+                }
+            } else {
+                string name = FindPlayerNameForConnection(argId, inLobby);
+                if (!String.IsNullOrEmpty(name)) {
+                    ReturnToSender(String.Format("{0}: {1}",argId,name));
+                } else {
+                    ReturnToSender(String.Format("LISTPLAYERS: no player with connection id {0}",argId));
+                }
+            }
+            return false;
+        }
+        
         // trim down the fields in candidate so that it doesn't alias authenticated
         // Return values is the same as MPBanEntry.trim
         private int TrimBanCandidate(ref MPBanEntry candidate, MPBanEntry authenticated) {

--- a/GameMod/ServerTrackerPost.cs
+++ b/GameMod/ServerTrackerPost.cs
@@ -43,7 +43,7 @@ namespace GameMod
     [HarmonyPatch(typeof(Server), "SendPlayersInLobbyToAllClients")]
     class ServerLobbyStatus
     {
-        public static void Postfix()
+        public static void SendToTracker()
         {
             MatchState state = NetworkMatch.GetMatchState();
             if (state != MatchState.LOBBY && state != MatchState.LOBBY_LOADING_SCENE && state != MatchState.LOBBY_LOAD_COUNTDOWN)
@@ -54,6 +54,11 @@ namespace GameMod
             obj["type"] = "LobbyStatus";
 
             ServerStatLog.TrackerPostStats(obj);
+        }
+
+        public static void Postfix()
+        {
+            SendToTracker();
         }
     }
 }

--- a/ServerCommands.md
+++ b/ServerCommands.md
@@ -24,6 +24,7 @@ see [the section on privilege management below](#privilege-management) for detai
  * `/SAY`: send a message to all players which are not blocked for chat
  * `/TEST <player>`: Test player name selection. No permission required for this command.
  * `/SWITCHTEAM [<player>]`: Switch the team a player is in. If used without an argument, it affects the player sending this command. Switching teams for players other than yourself requires chat command permissions.
+ * `/LISTPLAYERS [connectionId]`: List all connected players by their connection ID, or list the player for a given `connectionId`
 
 ### Player Name Matching
 

--- a/ServerCommands.md
+++ b/ServerCommands.md
@@ -24,12 +24,14 @@ see [the section on privilege management below](#privilege-management) for detai
  * `/SAY`: send a message to all players which are not blocked for chat
  * `/TEST <player>`: Test player name selection. No permission required for this command.
  * `/SWITCHTEAM [<player>]`: Switch the team a player is in. If used without an argument, it affects the player sending this command. Switching teams for players other than yourself requires chat command permissions.
- * `/LISTPLAYERS [connectionId]`: List all connected players by their connection ID, or list the player for a given `connectionId`
+ * `/LISTPLAYERS [connectionId1 [connectionId2]]`: List players by their connection ID. If no arguments are given, all players are listed. If a single argument is given, it is treated as a connection ID and only
+   the player on that ID is queried. If two arguments are given (separated by a single space character), they are treated as a range of connection IDs. Since the chat history shows at most 8 entries, you can split it into multiple queries that way.
 
 ### Player Selection and Name Matching
 
 The argument `<player>` may either be a string pattern to match for a player name, or a connection ID, when the prefix `CONN:` or `C:` is given (like `CONN:2`, use `/LISTPLAYERS` command to get the IDs).
-You can always use the `/TEST` command to find out which player a specific `<player>` argument would select.
+You can always use the `/TEST` command to find out which player a specific `<player>` argument would select. The selection by connection ID is useful when there are player names with characters which 
+can't be typed in your current language.
 
 Player names are matched to the `<player>` pattern as follows:
  * If the name matches completely, that player is selected

--- a/ServerCommands.md
+++ b/ServerCommands.md
@@ -20,7 +20,7 @@ see [the section on privilege management below](#privilege-management) for detai
  * `/GIVEPERM <player>`: grant a player the chat command permissions.
  * `/REVOKEPERM [<player>]`: revoke chat command permissions from a player or all players.
  * `/AUTH password`: a server operator can also start the server with the commandline argument `-chatCommandPassword serverPassword`. Any Player knowing this password can get to authenticated state with this command. If no `serverPassword` is set, this command always fails. Note that the password check is **not** case-sensitive.
- * `/STATUS`: short info about chat command and ban status. No permission required for this command.
+ * `/STATUS` or `/INFO`: short info about chat command and ban status. No permission required for this command.
  * `/SAY`: send a message to all players which are not blocked for chat
  * `/TEST <player>`: Test player name selection. No permission required for this command.
  * `/SWITCHTEAM [<player>]`: Switch the team a player is in. If used without an argument, it affects the player sending this command. Switching teams for players other than yourself requires chat command permissions.

--- a/ServerCommands.md
+++ b/ServerCommands.md
@@ -26,9 +26,12 @@ see [the section on privilege management below](#privilege-management) for detai
  * `/SWITCHTEAM [<player>]`: Switch the team a player is in. If used without an argument, it affects the player sending this command. Switching teams for players other than yourself requires chat command permissions.
  * `/LISTPLAYERS [connectionId]`: List all connected players by their connection ID, or list the player for a given `connectionId`
 
-### Player Name Matching
+### Player Selection and Name Matching
 
-Player names are matches the `<player>` pattern as follows:
+The argument `<player>` may either be a string pattern to match for a player name, or a connection ID, when the prefix `CONN:` or `C:` is given (like `CONN:2`, use `/LISTPLAYERS` command to get the IDs).
+You can always use the `/TEST` command to find out which player a specific `<player>` argument would select.
+
+Player names are matched to the `<player>` pattern as follows:
  * If the name matches completely, that player is selected
  * If only one player name contains the pattern, that player is selected.
  * If several player names contain the pattern:


### PR DESCRIPTION
Since players might choose names with all non-ASCII characters which might not be type-able in the current language settings of a client, it might be impossible to kick or ban such a player. This adds a new scheme to select players by their connection ID (on the server). This is done with the `CONN:` (or short `C:`)  prefix in the player selection pattern. A new `/LISTPLAYERS`  command is added to find out which connection ID each player has.

Additionally, the following improvements to the chat commands were made:
- The `/STATUS` command can now be invoked also by `/INFO`, or in short `/I`.
- The `/START` and `/EXTEND` commands now inform the tracker. Continuously extending the lobby will not get the game unlisted from the tracker any more, as long as each individual extension is less than 5 minutes. 
- The returned server answer for the `/START` and `/EXTEND` command now specify the exact number of seconds as used in the command argument.

The ServerCommands.md documentation is updated accordingly.