### PR TITLE
Fix ResolvePotentialNameCollision 

### DIFF
--- a/GameMod/MPValidatePlayerNames.cs
+++ b/GameMod/MPValidatePlayerNames.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using HarmonyLib;
 using Overload;
 
@@ -16,8 +18,37 @@ namespace GameMod {
     /// </summary>
     [HarmonyPatch(typeof(Overload.Server), "ResolvePotentialNameCollision")]
     class MPValidatePlayerNames {
-        public static void Prefix(PlayerLobbyData pld) {
+        // Helper function: get the player name without the "<X>" number suffix, and the number
+        // The suffix can be one or two digits.
+        private static string GetBaseName(string name, out int number)
+        {
+            number = 0;
+            if (String.IsNullOrEmpty(name)) {
+                return "";
+            }
+            if (name.EndsWith(">")) {
+                int idxStart = name.LastIndexOf(" <");
+                if (idxStart > 0) {
+                    int len = name.Length - idxStart - 3;
+                    if (len >= 1 && len <= 2) {
+                        string potentialNumber = name.Substring(idxStart+2, len);
+                        if (int.TryParse(potentialNumber, NumberStyles.Number, CultureInfo.InvariantCulture, out number)) {
+                            if (number > 0) {
+                                name = name.Substring(0, idxStart);
+                            } else {
+                                number = 0;
+                            }
+                        }
+                    }
+                }
+            }
+            return name;
+        }
+
+        // completely replace ResolvePotentialNameCollision() by a fixed and improved version
+        public static bool Prefix(PlayerLobbyData pld) {
             if (pld != null) {
+                // Step 1: validate name
                 bool nameValid = false;
                 if (!String.IsNullOrEmpty(pld.m_name)) {
                     pld.m_name = pld.m_name.ToUpper(); // only uppercase
@@ -41,7 +72,32 @@ namespace GameMod {
                 if (!nameValid) {
                     pld.m_name = "<INVALID NAME>";
                 }
+
+                // Step 2: resolve any name collisions
+                // Picks the lowest free number for this name, beginning from 2
+                ulong collisionSet = 0;
+                foreach (KeyValuePair<int, PlayerLobbyData> player in NetworkMatch.m_players) {
+                    PlayerLobbyData otherPlayerValue = player.Value;
+                    if (pld != otherPlayerValue) {
+                        int number;
+                        string baseName = GetBaseName(otherPlayerValue.m_name, out number);
+                        if (baseName == pld.m_name) {
+                            // same base name as we, mark as used
+                            collisionSet = collisionSet | (((ulong)1)<<(number&63));
+                        }
+                    }
+                }
+                if (collisionSet != 0) {
+                    int idx;
+                    for (idx=2; idx<64; idx++) {
+                        if ( (collisionSet & (((ulong)1)<<idx)) == 0) {
+                            break;
+                        }
+                    }
+                    pld.m_name = String.Format("{0} <{1}>", pld.m_name, idx);
+                }
             }
+            return false; // skip the original in every case
         }
     }
 }


### PR DESCRIPTION
This addresses github issue #309:

- on collision, this picks the lowest not used number, beginning with 2
- use angle brackets for the numbering (not parentheses as before) to prevent shenanigans with names which already include such suffixes