### PR TITLE
Stops logging the entire exception when saving a pilot file failed due to missing write permissions

### DIFF
--- a/GameMod/Controllers.cs
+++ b/GameMod/Controllers.cs
@@ -590,6 +590,11 @@ namespace GameMod
             }
             catch (Exception ex)
             {
+                if (ex is UnauthorizedAccessException)
+                {
+                    Debug.Log("Error in ControlsMod.SaveControlData: Could not save pilot file due to insufficient permissions");
+                    return;
+                }
                 Debug.LogException(ex);
                 GameManager.DebugOut("Error in ControlsMod.SaveControlData: " + ex.Message, 15f);
             }

--- a/GameMod/ExtendedConfig.cs
+++ b/GameMod/ExtendedConfig.cs
@@ -401,7 +401,12 @@ namespace GameMod
             }
             catch (Exception ex)
             {
-                Debug.Log("Error in ExtendedConfig.SaveActivePilot(): " + ex);
+                if (ex is UnauthorizedAccessException)
+                {
+                    Debug.Log("Error in ExtendedConfig.SaveActivePilot: Could not save pilot file due to insufficient permissions");
+                    return;
+                }
+                Debug.Log("Error in ExtendedConfig.SaveActivePilot: " + ex);
             }
         }
 


### PR DESCRIPTION
setting your config files to read only is an often used way in games like apex/overwatch to ensure that complex configurations with multitudes of honed in settings dont change without having to check them individually.

from a purely functional perspective this also works in overload and gets handled correctly but the logged exceptions look awful as if begging for a fix.
so this tiny patch reduces 

```
Unhandled Exception detected: UnauthorizedAccessException: Access to the path "\\?\C:\Users\denda\AppData\LocalLow\Revival\Overload\Stoffelch.xconfigmod" is denied.
 
(Filename: C:\buildslave\unity\build\artifacts/generated/common/runtime/DebugBindings.gen.cpp Line: 51)

System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options)
System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share)
(wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)
System.IO.StreamWriter..ctor (System.String path, Boolean append, System.Text.Encoding encoding, Int32 bufferSize)
System.IO.StreamWriter..ctor (System.String path, Boolean append, System.Text.Encoding encoding)
(wrapper remoting-invoke-with-check) System.IO.StreamWriter:.ctor (string,bool,System.Text.Encoding)
System.IO.File.WriteAllText (System.String path, System.String contents, System.Text.Encoding encoding)
System.IO.File.WriteAllText (System.String path, System.String contents)
Overload.Platform.WriteTextUserData (System.String filename, System.String text)
GameMod.Controllers_Controls_SaveControlData.Postfix (System.String filename)
UnityEngine.Debug:LogException(Exception)
GameMod.Controllers_Controls_SaveControlData:Postfix(String)
Overload.Controls:Overload.Controls.SaveControlData_Patch2(String)
Overload.PilotManager:Overload.PilotManager.Save_Patch0(Boolean)
Overload.GameManager:OnApplicationQuit()

 
(Filename: C:\buildslave\unity\build\artifacts/generated/common/runtime/DebugBindings.gen.cpp Line: 51)

UnauthorizedAccessException: Access to the path "\\?\C:\Users\denda\AppData\LocalLow\Revival\Overload\Stoffelch.xconfigmod" is denied.
  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options) [0x00000] in <filename unknown>:0 
  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)
  at System.IO.StreamWriter..ctor (System.String path, Boolean append, System.Text.Encoding encoding, Int32 bufferSize) [0x00000] in <filename unknown>:0 
  at System.IO.StreamWriter..ctor (System.String path, Boolean append, System.Text.Encoding encoding) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.IO.StreamWriter:.ctor (string,bool,System.Text.Encoding)
  at System.IO.File.WriteAllText (System.String path, System.String contents, System.Text.Encoding encoding) [0x00000] in <filename unknown>:0 
  at System.IO.File.WriteAllText (System.String path, System.String contents) [0x00000] in <filename unknown>:0 
  at Overload.Platform.WriteTextUserData (System.String filename, System.String text) [0x00000] in <filename unknown>:0 
  at GameMod.Controllers_Controls_SaveControlData.Postfix (System.String filename) [0x00000] in <filename unknown>:0 
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:LogException(Exception)
GameMod.Controllers_Controls_SaveControlData:Postfix(String)
Overload.Controls:Overload.Controls.SaveControlData_Patch2(String)
Overload.PilotManager:Overload.PilotManager.Save_Patch0(Boolean)
Overload.GameManager:OnApplicationQuit()
 
(Filename:  Line: -1)

Error in ExtendedConfig.SaveActivePilot(): System.UnauthorizedAccessException: Access to the path "C:\Users\denda\AppData\LocalLow\Revival\Overload\Stoffelch.extendedconfig" is denied.

  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options) [0x00000] in <filename unknown>:0 

  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share) [0x00000] in <filename unknown>:0 

  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)

  at System.IO.StreamWriter..ctor (System.String path, Boolean append, System.Text.Encoding encoding, Int32 bufferSize) [0x00000] in <filename unknown>:0 

  at System.IO.StreamWriter..ctor (System.String path, Boolean append) [0x00000] in <filename unknown>:0 

  at (wrapper remoting-invoke-with-check) System.IO.StreamWriter:.ctor (string,bool)

  at System.IO.File.CreateText (System.String path) [0x00000] in <filename unknown>:0 

  at GameMod.ExtendedConfig.SaveActivePilot () [0x00000] in <filename unknown>:0 
```

to a less severe and serious looking message
```
Error in ControlsMod.SaveControlData: Could not save pilot file due to insufficient permissions
Error in ExtendedConfig.SaveActivePilot: Could not save pilot file due to insufficient permissions
```