### PR TITLE
m_spinup_starting_time: deal with DOS and UNIX style line endings more robustly

### DIFF
--- a/GameMod/PresetData.cs
+++ b/GameMod/PresetData.cs
@@ -98,9 +98,9 @@ namespace GameMod
             if (index != -1)
             {
                 var spinup = projData.Substring(index + 23, 1);
-                var hasCrLf = projData.Substring(index + 24, 1) == "\r" || projData.Substring(index + 24, 1) == "\n";
+                var newlineIndex = projData.IndexOf('\n', index + 24, 2);
 
-                if (!hasCrLf || !(new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8" }.Contains(spinup)))
+                if (newlineIndex < index+24 || newlineIndex > index+26 || !(new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8" }.Contains(spinup)))
                 {
                     Cyclone.CycloneSpinupStartingStep = 0;
 
@@ -110,7 +110,7 @@ namespace GameMod
                 {
                     Cyclone.CycloneSpinupStartingStep = int.Parse(spinup);
 
-                    projData = string.Format("{0}{1}", projData.Substring(0, index), projData.Substring(index + 26));
+                    projData = projData.Substring(0, index) + projData.Substring(newlineIndex+1);
                 }
             }
             else


### PR DESCRIPTION
This is a follow-up to c8e55a3319dd3a5e00ce664873346773a8b7ae32

When I compiled 0.5.12 on Linux, I noticed that the server runs into an exception in `ReadProjPresetData`, while the pre-compiled 0.5.12 provided for download did not.

As it turned out, the issue was that the `projData` string looked like this:

```
[...]
proj_vortex
_damage_robot;7
[...]
```

with the inital `m` character missing...

The reason is https://github.com/overload-development-community/olmod/blob/48c18f519495c267c2aacccbbbf79877370ba4af/GameMod/PresetData.cs#L113

This assumes that a full CRLF `\r\n` string sequence is present as it skips 2 characters after the value. 

However, the default projData content is a raw string in `MPModPrivateData.cs`. My _assumption_ here is that when you compile this project on Windows, you have set up your git so that line endings will be DOS-Style CRLF on checkout, but the checked in files in the repo will be UNIX-style LF (as they should be) . But when I check out this file on Linux, I get the UNIX-stlye line endings, and the string which is compiled into the binary doesn't contain the CRs in the first place.

Note that this issue could also be present with custom projdata files from users, as they might use both line ending conventions.

This small patch makes the handling more robust so that it can deal with both line ending conventions. 