### PR TITLE
Fixed an observer check in the fire packet that was missed from a previous patch

### DIFF
--- a/GameMod/MPEnhancedFirePacket.cs
+++ b/GameMod/MPEnhancedFirePacket.cs
@@ -15,7 +15,7 @@ namespace GameMod
         {
             foreach (Player player2 in Overload.NetworkManager.m_Players)
             {
-                if ((bool)player2 && !player2.isLocalPlayer && !player2.m_spectator)
+                if ((bool)player2 && !player2.isLocalPlayer)
                 {
                     if (MPTweaks.ClientHasTweak(player2.connectionToClient.connectionId, "efirepacket"))
                     {


### PR DESCRIPTION
There was a transpiler already removing the m_spectator check from SendProjectileFiredToClients() that I missed when creating the replacement method. Without this, spectators don't see any projectiles on 0.5.12 servers.