### PR TITLE
Add Multiplayer game option to forbid/disable certain weapons in the loadouts.

### DIFF
--- a/GameMod/Console.cs
+++ b/GameMod/Console.cs
@@ -233,6 +233,14 @@ namespace GameMod {
             }
         }
 
+        static void CmdLoadoutMask()
+        {
+            if (uConsole.GetNumParameters() > 0) {
+                MPLoadouts.LoadoutFilterBitmask = uConsole.GetInt();
+            }
+            Debug.LogFormat("loadout mask: {0} = {0:X8}", MPLoadouts.LoadoutFilterBitmask);
+        }
+
         public static void RegisterCommands()
         {
             uConsole.RegisterCommand("mute", "Mute a specific player", new uConsole.DebugCommand(MutePlayer));
@@ -244,6 +252,7 @@ namespace GameMod {
             uConsole.RegisterCommand("ui_color", "Set UI color #aabbcc", new uConsole.DebugCommand(CmdUIColor));
             uConsole.RegisterCommand("vr_scale", "Set VR scale (0.1 to 10)", new uConsole.DebugCommand(CmdVRScale));
             uConsole.RegisterCommand("xp", "Set XP", new uConsole.DebugCommand(CmdXP));
+            uConsole.RegisterCommand("loadout_mask", "Manually set the loadout mask", CmdLoadoutMask);
         }
     }
 

--- a/GameMod/Debugging.cs
+++ b/GameMod/Debugging.cs
@@ -153,6 +153,9 @@ namespace GameMod {
         static bool Prefix(PlayerShip __instance, bool force_visible = false, WeaponType wt = WeaponType.NUM) {
             if (wt == WeaponType.NUM) {
                 wt = __instance.c_player.m_weapon_type;
+                if (wt == WeaponType.NUM) {
+                    return false;
+                }
             }
             if (__instance.IsCockpitVisible || force_visible || !__instance.isLocalPlayer) {
                 for (int i = 0; i < 8; i++) {

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -1302,7 +1302,8 @@ namespace GameMod
             //uConsole.Log("Fire: " + MenuManager.m_menu_micro_state + " : " + UIManager.m_menu_selection);
 
             // Disables reflex powerups since it's provided as a standard sidearm now.
-            if (!Menus.mms_classic_spawns && !MPLoadouts.IsAllowedByFilter(WeaponType.REFLEX, MPLoadouts.LoadoutFilterBitmask))
+            // But if Reflex is forbidden in the loadout settings, you may add it as powerup
+            if (!Menus.mms_classic_spawns && MPLoadouts.IsAllowedByFilter(WeaponType.REFLEX, MPLoadouts.LoadoutFilterBitmask))
             {
                 MenuManager.mms_powerup_filter[2] = false;
             }

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -1247,7 +1247,7 @@ namespace GameMod
                     Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
                     position.y += 62f;
                     __instance.DrawLabelSmall(Vector2.up * (UIManager.UI_TOP + 70f), Loc.LS("ALLOWED LOADOUT WEAPONS"), 250f, 24f, 1f);
-                    position.y = -130f;
+                    position.y = -133f;
                     __instance.DrawMenuSeparator(position - Vector2.up * 40f);
                     position.y += 40f;
                     __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("PRIMARY WEAPONS"), 300f);
@@ -1265,7 +1265,7 @@ namespace GameMod
                         __instance.SelectAndDrawCheckboxItem(weaponNameNoDefault2, position + Vector2.right * (((float)j - 1.5f) * 320f), num2, MPLoadouts.IsAllowed((WeaponType)num2), false, 0.5f, -1);
                     }
                     position.y += 62f;
-                    position.y += 30f;
+                    position.y += 40f;
                     __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("SECONDARY WEAPONS"), 300f);
                     for (int k = 0; k < 4; k++)
                     {

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -914,7 +914,9 @@ namespace GameMod
             color.a = uie.m_alpha;
             UIManager.DrawQuadBarHorizontal(pos, 11f, 11f, num, color, 8);
             color = ((!highlight) ? UIManager.m_col_ui1 : UIManager.m_col_ui5);
-            UIManager.DrawSpriteUI(pos - Vector2.right * (num * 0.5f + 2f), 0.16f, 0.16f, color, uie.m_alpha, (int)(26 + wt));
+            if (wt < WeaponType.NUM) {
+                UIManager.DrawSpriteUI(pos - Vector2.right * (num * 0.5f + 2f), 0.16f, 0.16f, color, uie.m_alpha, (int)(26 + wt));
+            }
             uie.DrawStringSmall(Player.GetWeaponNameNoDefault(wt), pos - Vector2.right * (num * 0.5f - 10f), 0.4f, StringOffset.LEFT, color, 1f, num * 0.95f);
         }
 
@@ -925,7 +927,9 @@ namespace GameMod
             color.a = uie.m_alpha;
             UIManager.DrawQuadBarHorizontal(pos, 11f, 11f, num, color, 8);
             color = ((!highlight) ? UIManager.m_col_ui1 : UIManager.m_col_ui5);
-            UIManager.DrawSpriteUI(pos - Vector2.right * (num * 0.5f + 2f), 0.16f, 0.16f, color, uie.m_alpha, (int)(104 + mt));
+            if (mt < MissileType.NUM) {
+                UIManager.DrawSpriteUI(pos - Vector2.right * (num * 0.5f + 2f), 0.16f, 0.16f, color, uie.m_alpha, (int)(104 + mt));
+            }
             uie.DrawStringSmall(Player.GetMissileNameNoDefault(mt), pos - Vector2.right * (num * 0.5f - 10f), 0.4f, StringOffset.LEFT, color, 1f, num * 0.95f);
         }
 

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -234,8 +234,8 @@ namespace GameMod
                 int weaponCnt = weapons.Count;
                 int missileCnt = missiles.Count;
 
-                Debug.LogFormat("Loadout filter: XX: {0}", filter);
-                Debug.LogFormat("Loadout filter: before: {0}", Describe());
+                //Debug.LogFormat("Loadout filter: XX: {0}", filter);
+                //Debug.LogFormat("Loadout filter: before: {0}", Describe());
 
                 // filter out not allowed entries, replace by allowed ones
                 for (i=0; i<weapons.Count; i++) {
@@ -260,15 +260,15 @@ namespace GameMod
                 CleanupList<WeaponType>(weapons, WeaponType.NUM);
                 CleanupList<MissileType>(missiles, MissileType.NUM);
 
-                // Overload crashes when used without any weapon
                 /*
+                // Overload crashes when used without any weapon
                 if (weapons.Count > 0 && weapons[0] == WeaponType.NUM) {
                     weapons[0] = (WeaponType)0;
                 }
                 */
 
 
-                Debug.LogFormat("Loadout filter: after: {0}", Describe());
+                //Debug.LogFormat("Loadout filter: after: {0}", Describe());
                 return replaced;
             }
 

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -505,26 +505,6 @@ namespace GameMod
     [HarmonyPatch(typeof(Server), "SendLoadoutDataToClients")]
     internal class MPLoadouts_Server_SendLoadoutDataToClients
     {
-        /*
-        static void Prefix()
-        {
-            foreach (var kvp in MPLoadouts.NetworkLoadouts)
-            {
-                foreach (var loadout in kvp.Value.loadouts)
-                {
-                    loadout.weapons.RemoveAll(weapon => weapon == WeaponType.IMPULSE);
-                    loadout.weapons.Clear();
-                    loadout.missiles.Clear();
-                    loadout.weapons.Add(WeaponType.THUNDERBOLT);
-                    loadout.weapons.Add(WeaponType.NUM);
-                    loadout.missiles.Add(MissileType.NUM);
-                    loadout.missiles.Add(MissileType.NUM);
-
-                }
-            }
-        }
-        */
-
         static void Postfix()
         {
             foreach (var player in Overload.NetworkManager.m_Players.Where(x => x.connectionToClient.connectionId > 0))

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -1135,19 +1135,6 @@ namespace GameMod
         }
     }
 
-    // Disables reflex powerups since it's provided as a standard sidearm now.
-    [HarmonyPatch(typeof(MenuManager), "MpMatchSetup")]
-    internal class MPLoadouts_MenuManager_MpMatchSetup
-    {
-        public static void Postfix()
-        {
-            if (!Menus.mms_classic_spawns && !MPLoadouts.IsAllowedByFilter(WeaponType.REFLEX, MPLoadouts.LoadoutFilterBitmask))
-            {
-                MenuManager.mms_powerup_filter[2] = false;
-            }
-        }
-    }
-
     // Take care about the old-style loadout messages, especially apply the filters there, too
     [HarmonyPatch(typeof(NetworkMatch), "UpdatePlayerLoadout")]
     class MPLoadouts_NetworkMatch_UpdatePlayerLoadout {
@@ -1231,6 +1218,8 @@ namespace GameMod
     // Draw Selection Menu 
     [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
     class MPLoadouts_UIElement_DrawMpMatchSetup {
+
+        [HarmonyPriority(Priority.Normal + 1)]
         private static void Postfix(UIElement __instance)
         {
             
@@ -1238,45 +1227,47 @@ namespace GameMod
             {
                 case 15:
                     Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
-            	    __instance.DrawLabelSmall(Vector2.up * (UIManager.UI_TOP + 70f), Loc.LS("ALLOWED LOADOUT WEAPONS"), 250f, 24f, 1f);
-				    position.y = -100f;
-				    __instance.DrawMenuSeparator(position - Vector2.up * 40f);
-				    position.y += 40f;
-				    __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("PRIMARY WEAPONS"), 300f);
-				    for (int i = 0; i < 4; i++)
-				    {
-					    string weaponNameNoDefault = Player.GetWeaponNameNoDefault((WeaponType)i);
-					    int num = i;
-					    __instance.SelectAndDrawCheckboxItem(weaponNameNoDefault, position + Vector2.right * (((float)i - 1.5f) * 320f), num, MenuManager.mms_powerup_filter[num], false, 0.5f, -1);
-				    }
-				    position.y += 62f;
-				    for (int j = 0; j < 4; j++)
-			    	{
-			    		string weaponNameNoDefault2 = Player.GetWeaponNameNoDefault(j + WeaponType.DRILLER);
-			      		int num2 = j + 4;
-			    		__instance.SelectAndDrawCheckboxItem(weaponNameNoDefault2, position + Vector2.right * (((float)j - 1.5f) * 320f), num2, MenuManager.mms_powerup_filter[num2], false, 0.5f, -1);
-			    	}
-			    	position.y += 62f;
-			    	position.y += 80f;
-				    __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("SECONDARY WEAPONS"), 300f);
-			    	for (int k = 0; k < 4; k++)
-				    {
-			    		string missileNameNoDefault = Player.GetMissileNameNoDefault((MissileType)k);
-			    		int num3 = k + 8;
-				    	__instance.SelectAndDrawCheckboxItem(missileNameNoDefault, position + Vector2.right * (((float)k - 1.5f) * 320f), num3, MenuManager.mms_powerup_filter[num3], false, 0.5f, -1);
-			    	}
-			    	position.y += 62f;
-			    	for (int l = 0; l < 4; l++)
-			    	{
-			    		string missileNameNoDefault2 = Player.GetMissileNameNoDefault(l + MissileType.NOVA);
-			    		int num4 = l + 12;
-				    	__instance.SelectAndDrawCheckboxItem(missileNameNoDefault2, position + Vector2.right * (((float)l - 1.5f) * 320f), num4, MenuManager.mms_powerup_filter[num4], false, 0.5f, -1);
-				    }
-				    __instance.DrawMenuSeparator(position + Vector2.up * 40f);
-				    position.y += 80.6f;
-				    __instance.SelectAndDrawHalfItem2(Loc.LS("CLEAR"), position - Vector2.right * 160f, 20, false);
-				    __instance.SelectAndDrawHalfItem2(Loc.LS("RESET"), position + Vector2.right * 160f, 21, false);
-				    break;
+                    position.y += 62f;
+                    __instance.DrawLabelSmall(Vector2.up * (UIManager.UI_TOP + 70f), Loc.LS("ALLOWED LOADOUT WEAPONS"), 250f, 24f, 1f);
+                    position.y = -130f;
+                    __instance.DrawMenuSeparator(position - Vector2.up * 40f);
+                    position.y += 40f;
+                    __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("PRIMARY WEAPONS"), 300f);
+                    for (int i = 0; i < 4; i++)
+                    {
+                        string weaponNameNoDefault = Player.GetWeaponNameNoDefault((WeaponType)i);
+                        int num = i;
+                        __instance.SelectAndDrawCheckboxItem(weaponNameNoDefault, position + Vector2.right * (((float)i - 1.5f) * 320f), num, MPLoadouts.IsAllowed((WeaponType)num), false, 0.5f, -1);
+                    }
+                    position.y += 62f;
+                    for (int j = 0; j < 4; j++)
+                    {
+                        string weaponNameNoDefault2 = Player.GetWeaponNameNoDefault(j + WeaponType.DRILLER);
+                        int num2 = j + 4;
+                        __instance.SelectAndDrawCheckboxItem(weaponNameNoDefault2, position + Vector2.right * (((float)j - 1.5f) * 320f), num2, MPLoadouts.IsAllowed((WeaponType)num2), false, 0.5f, -1);
+                    }
+                    position.y += 62f;
+                    position.y += 30f;
+                    __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("SECONDARY WEAPONS"), 300f);
+                    for (int k = 0; k < 4; k++)
+                    {
+                        string missileNameNoDefault = Player.GetMissileNameNoDefault((MissileType)k);
+                        int num3 = k + 8;
+                        __instance.SelectAndDrawCheckboxItem(missileNameNoDefault, position + Vector2.right * (((float)k - 1.5f) * 320f), num3, MPLoadouts.IsAllowed((MissileType)k), false, 0.5f, -1);
+                    }
+                    position.y += 62f;
+                    for (int l = 0; l < 4; l++)
+                    {
+                        string missileNameNoDefault2 = Player.GetMissileNameNoDefault(l + MissileType.NOVA);
+                        int num4 = l + 12;
+                        __instance.SelectAndDrawCheckboxItem(missileNameNoDefault2, position + Vector2.right * (((float)l - 1.5f) * 320f), num4, MPLoadouts.IsAllowed((MissileType)(l + MissileType.NOVA)), false, 0.5f, -1);
+                    }
+                    __instance.DrawMenuSeparator(position + Vector2.up * 40f);
+                    position.y += 80.6f;
+                    __instance.SelectAndDrawHalfItem2(Loc.LS("ALLOWED POWERUPS"), position - Vector2.right * 470f, 22, false);
+                    __instance.SelectAndDrawHalfItem2(Loc.LS("CLEAR"), position - Vector2.right * 160f, 20, false);
+                    __instance.SelectAndDrawHalfItem2(Loc.LS("RESET"), position + Vector2.right * 160f, 21, false);
+                    break;
                 default:
                     break;
             }
@@ -1285,44 +1276,111 @@ namespace GameMod
 
     // Handle Logic for Selection Menu
     [HarmonyPatch(typeof(MenuManager), "MpMatchSetup")]
-        class MPLoadouts_MenuManager_MpMatchSetup_II
+    class MPLoadouts_MenuManager_MpMatchSetup
+    {
+        [HarmonyPriority(Priority.Normal + 1)]
+        static void Postfix()
         {
-            static void Postfix()
-            {
-                if (!UIManager.PushedSelect(100) && (!MenuManager.option_dir || !UIManager.PushedDir()))
-                    return;
+            //uConsole.Log("Fire: " + MenuManager.m_menu_micro_state + " : " + UIManager.m_menu_selection);
 
-                switch (MenuManager.m_menu_micro_state)
-                {
-                    case 6:
-                        switch (UIManager.m_menu_selection)
-                        {
-                            case 23:
-                                MenuManager.m_menu_micro_state = 15;
-                                MenuManager.UIPulse(2f);
-                                MenuManager.PlaySelectSound(1f);
-                                return;
-                            case 100:
-                                MenuManager.m_menu_micro_state = 6;
-                                MenuManager.UIPulse(2f);
-                                MenuManager.PlaySelectSound(1f);
-                                return;
-                            default:
-                                return;
-                        }
-                    case 15:
-                        switch (UIManager.m_menu_selection)
-                        {
-                            
-                            case 100:
-                                MenuManager.m_menu_micro_state = 6;
-                                MenuManager.UIPulse(2f);
-                                MenuManager.PlaySelectSound(1f);
-                                return;
-                            default:
-                                return;
-                        }
-                }
+            // Disables reflex powerups since it's provided as a standard sidearm now.
+            if (!Menus.mms_classic_spawns && !MPLoadouts.IsAllowedByFilter(WeaponType.REFLEX, MPLoadouts.LoadoutFilterBitmask))
+            {
+                MenuManager.mms_powerup_filter[2] = false;
+            }
+
+            if (!UIManager.PushedSelect(100) && (!MenuManager.option_dir || !UIManager.PushedDir()))
+                return;
+
+            switch (MenuManager.m_menu_micro_state)
+            {
+                case 6:
+                    switch (UIManager.m_menu_selection)
+                    {
+                        // Button to lead into the "Allowed Loadouts Weapon" Menu
+                        case 23:
+                            MenuManager.m_menu_micro_state = 15;
+                            MenuManager.UIPulse(2f);
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        case 100:
+                            MenuManager.m_menu_micro_state = 6;
+                            MenuManager.UIPulse(2f);
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        default:
+                            return;
+                    }
+                // Handling for the Backlink button in the allowed powerups menu
+                case 7:
+                    switch (UIManager.m_menu_selection)
+                    {
+                        case 30:
+                            MenuManager.m_menu_micro_state = 15;
+                            MenuManager.UIPulse(2f);
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        default:
+                            return;
+                    }
+                // The "Allowed Loadout Weapons" Menu
+                case 15:
+                    switch (UIManager.m_menu_selection)
+                    {
+                        // Primary Weapons
+                        case 0:
+                        case 1:
+                        case 2:
+                        case 3:
+                        case 4:
+                        case 5:
+                        case 6:
+                        case 7:
+                            MPLoadouts.SetAllowed((WeaponType)UIManager.m_menu_selection, !MPLoadouts.IsAllowed((WeaponType)UIManager.m_menu_selection));
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        // Secondary Weapons
+                        case 8:
+                        case 9:
+                        case 10:
+                        case 11:
+                        case 12:
+                        case 13:
+                        case 14:
+                        case 15:
+                            MPLoadouts.SetAllowed((MissileType)UIManager.m_menu_selection - 8, !MPLoadouts.IsAllowed((MissileType)UIManager.m_menu_selection - 8));
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        // Clear All Button
+                        case 20:
+                            for (int i = 0; i < 8; i++)
+                            {
+                                MPLoadouts.SetAllowed((WeaponType)i, false);
+                                MPLoadouts.SetAllowed((MissileType)i, false);
+                            }
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        // Set Default State Button
+                        case 21:
+                            MPLoadouts.LoadoutFilterBitmask = MPLoadouts.MASK_DEFAULT;
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        // Switch to Powerup menu
+                        case 22:
+                            MenuManager.m_menu_micro_state = 7;
+                            MenuManager.UIPulse(2f);
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        // Back to parent menu Button
+                        case 100:
+                            MenuManager.m_menu_micro_state = 6;
+                            MenuManager.UIPulse(2f);
+                            MenuManager.PlaySelectSound(1f);
+                            return;
+                        default:
+                            return;
+                    }
             }
         }
+    }
 }

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -263,6 +263,24 @@ namespace GameMod
     [HarmonyPatch(typeof(Server), "SendLoadoutDataToClients")]
     internal class MPLoadouts_Server_SendLoadoutDataToClients
     {
+        static void Prefix()
+        {
+            foreach (var kvp in MPLoadouts.NetworkLoadouts)
+            {
+                foreach (var loadout in kvp.Value.loadouts)
+                {
+                    loadout.weapons.RemoveAll(weapon => weapon == WeaponType.IMPULSE);
+                    loadout.weapons.Clear();
+                    loadout.missiles.Clear();
+                    loadout.weapons.Add(WeaponType.THUNDERBOLT);
+                    loadout.weapons.Add(WeaponType.NUM);
+                    loadout.missiles.Add(MissileType.NUM);
+                    loadout.missiles.Add(MissileType.NUM);
+
+                }
+            }
+        }
+
         static void Postfix()
         {
             foreach (var player in Overload.NetworkManager.m_Players.Where(x => x.connectionToClient.connectionId > 0))
@@ -432,15 +450,19 @@ namespace GameMod
 
                 foreach (var weapon in loadout.weapons)
                 {
-                    player.m_weapon_level[(int)weapon] = WeaponUnlock.LEVEL_1;
-                    if (Player.WeaponUsesAmmo2(weapon))
-                        num2++;
+                    if (weapon != WeaponType.NUM) {
+                        player.m_weapon_level[(int)weapon] = WeaponUnlock.LEVEL_1;
+                        if (Player.WeaponUsesAmmo2(weapon))
+                            num2++;
+                    }
                 }
 
                 foreach (var missile in loadout.missiles)
                 {
-                    player.m_missile_level[(int)missile] = WeaponUnlock.LEVEL_1;
-                    player.m_missile_ammo[(int)missile] = Player.MP_DEFAULT_MISSILE_AMMO[(int)missile];
+                    if (missile != MissileType.NUM) {
+                        player.m_missile_level[(int)missile] = WeaponUnlock.LEVEL_1;
+                        player.m_missile_ammo[(int)missile] = Player.MP_DEFAULT_MISSILE_AMMO[(int)missile];
+                    }
                 }
 
                 player.Networkm_weapon_type = loadout.weapons[0];

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -139,14 +139,14 @@ namespace GameMod
                     if (i > 0) {
                         desc = desc + ", ";
                     }
-                    desc = Player.GetWeaponNameNoDefault(weapons[i]);
+                    desc = desc + Player.GetWeaponNameNoDefault(weapons[i]);
                 }
                 desc = desc + "} missiles: {";
                 for(int i=0; i<missiles.Count; i++) {
                     if (i > 0) {
                         desc = desc + ", ";
                     }
-                    desc = Player.GetMissileNameNoDefault(missiles[i]);
+                    desc = desc + Player.GetMissileNameNoDefault(missiles[i]);
                 }
                 desc = desc + "}";
                 return desc;

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using System.Reflection;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -1040,20 +1041,25 @@ namespace GameMod
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
         {
             int state = 0;
+            if ((int)WeaponType.NUM  != 8) {// just to make sure...
+                throw new System.Exception("MPLoadouts_PlayerShip_SpewItemsOnDeath expects WeaponType.NUM == 8");
+            }
             foreach (var code in codes)
             {
                 if (state == 0) {
+                    if (code.opcode == OpCodes.Ldfld && ((FieldInfo)code.operand).Name == "m_weapon_type") {
+                        state = 1;
+                    }
+                } else if (state == 1) {
                     if (code.opcode == OpCodes.Ldelem_U1)
                     {
                         yield return new CodeInstruction(OpCodes.Ldc_I4_7);
                         yield return new CodeInstruction(OpCodes.And);
-                        state = 1;
+                        state = 2;
                     }
                 }
                 yield return code;
             }
         }
     }
-
-
 }

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -1185,4 +1185,103 @@ namespace GameMod
             }
         }
     }
+
+
+    // Draw Selection Menu 
+    [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
+    class MPLoadouts_UIElement_DrawMpMatchSetup {
+        private static void Postfix(UIElement __instance)
+        {
+            
+            switch (MenuManager.m_menu_micro_state)
+            {
+                case 15:
+                    Vector2 position = Vector2.up * (UIManager.UI_TOP + 70f);
+            	    __instance.DrawLabelSmall(Vector2.up * (UIManager.UI_TOP + 70f), Loc.LS("ALLOWED LOADOUT WEAPONS"), 250f, 24f, 1f);
+				    position.y = -100f;
+				    __instance.DrawMenuSeparator(position - Vector2.up * 40f);
+				    position.y += 40f;
+				    __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("PRIMARY WEAPONS"), 300f);
+				    for (int i = 0; i < 4; i++)
+				    {
+					    string weaponNameNoDefault = Player.GetWeaponNameNoDefault((WeaponType)i);
+					    int num = i;
+					    __instance.SelectAndDrawCheckboxItem(weaponNameNoDefault, position + Vector2.right * (((float)i - 1.5f) * 320f), num, MenuManager.mms_powerup_filter[num], false, 0.5f, -1);
+				    }
+				    position.y += 62f;
+				    for (int j = 0; j < 4; j++)
+			    	{
+			    		string weaponNameNoDefault2 = Player.GetWeaponNameNoDefault(j + WeaponType.DRILLER);
+			      		int num2 = j + 4;
+			    		__instance.SelectAndDrawCheckboxItem(weaponNameNoDefault2, position + Vector2.right * (((float)j - 1.5f) * 320f), num2, MenuManager.mms_powerup_filter[num2], false, 0.5f, -1);
+			    	}
+			    	position.y += 62f;
+			    	position.y += 80f;
+				    __instance.DrawSmallHeader1(position - Vector2.up * 51f, Loc.LS("SECONDARY WEAPONS"), 300f);
+			    	for (int k = 0; k < 4; k++)
+				    {
+			    		string missileNameNoDefault = Player.GetMissileNameNoDefault((MissileType)k);
+			    		int num3 = k + 8;
+				    	__instance.SelectAndDrawCheckboxItem(missileNameNoDefault, position + Vector2.right * (((float)k - 1.5f) * 320f), num3, MenuManager.mms_powerup_filter[num3], false, 0.5f, -1);
+			    	}
+			    	position.y += 62f;
+			    	for (int l = 0; l < 4; l++)
+			    	{
+			    		string missileNameNoDefault2 = Player.GetMissileNameNoDefault(l + MissileType.NOVA);
+			    		int num4 = l + 12;
+				    	__instance.SelectAndDrawCheckboxItem(missileNameNoDefault2, position + Vector2.right * (((float)l - 1.5f) * 320f), num4, MenuManager.mms_powerup_filter[num4], false, 0.5f, -1);
+				    }
+				    __instance.DrawMenuSeparator(position + Vector2.up * 40f);
+				    position.y += 80.6f;
+				    __instance.SelectAndDrawHalfItem2(Loc.LS("CLEAR"), position - Vector2.right * 160f, 20, false);
+				    __instance.SelectAndDrawHalfItem2(Loc.LS("RESET"), position + Vector2.right * 160f, 21, false);
+				    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    // Handle Logic for Selection Menu
+    [HarmonyPatch(typeof(MenuManager), "MpMatchSetup")]
+        class MPLoadouts_MenuManager_MpMatchSetup_II
+        {
+            static void Postfix()
+            {
+                if (!UIManager.PushedSelect(100) && (!MenuManager.option_dir || !UIManager.PushedDir()))
+                    return;
+
+                switch (MenuManager.m_menu_micro_state)
+                {
+                    case 6:
+                        switch (UIManager.m_menu_selection)
+                        {
+                            case 23:
+                                MenuManager.m_menu_micro_state = 15;
+                                MenuManager.UIPulse(2f);
+                                MenuManager.PlaySelectSound(1f);
+                                return;
+                            case 100:
+                                MenuManager.m_menu_micro_state = 6;
+                                MenuManager.UIPulse(2f);
+                                MenuManager.PlaySelectSound(1f);
+                                return;
+                            default:
+                                return;
+                        }
+                    case 15:
+                        switch (UIManager.m_menu_selection)
+                        {
+                            
+                            case 100:
+                                MenuManager.m_menu_micro_state = 6;
+                                MenuManager.UIPulse(2f);
+                                MenuManager.PlaySelectSound(1f);
+                                return;
+                            default:
+                                return;
+                        }
+                }
+            }
+        }
 }

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -1214,6 +1214,20 @@ namespace GameMod
         }
     }
 
+    // if loadout forbids all primaries, make sure to switch to the first weapon which is picked up
+    [HarmonyPatch(typeof(Player), "UnlockWeaponClient")]
+    class MPLoadouts_Player_UnlockWeaponClient
+    {
+        public static void Postfix(WeaponType wt, bool silent, Player __instance)
+        {
+            if (__instance.m_weapon_type >= WeaponType.NUM) {
+                __instance.Networkm_weapon_type = wt;
+                __instance.CallCmdSetCurrentWeapon(__instance.m_weapon_type);
+                __instance.c_player_ship.WeaponSelectFX();
+                __instance.UpdateCurrentWeaponName();
+            }
+        }
+    }
 
     // Draw Selection Menu 
     [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]

--- a/GameMod/MPLoadouts.cs
+++ b/GameMod/MPLoadouts.cs
@@ -38,6 +38,15 @@ namespace GameMod
             return (1<<(m + (int)MissileType.NUM));
         }
 
+        private static void SetFilterBit(int bit, bool allowed = true)
+        {
+            if (allowed) {
+                LoadoutFilterBitmask |= bit;
+            } else {
+                LoadoutFilterBitmask &= ~bit;
+            }
+        }
+
         public static bool IsAllowedByFilter(WeaponType weapon, int filter)
         {
             if (weapon >= WeaponType.NUM) {
@@ -52,6 +61,26 @@ namespace GameMod
                 return true; // the "no such missile" is also always allowed
             }
             return ( (filter & GetFilterBit(missile)) != 0);
+        }
+
+        public static bool IsAllowed(WeaponType weapon)
+        {
+            return IsAllowedByFilter(weapon, LoadoutFilterBitmask);
+        }
+
+        public static bool IsAllowed(MissileType missile)
+        {
+            return IsAllowedByFilter(missile, LoadoutFilterBitmask);
+        }
+
+        public static void SetAllowed(WeaponType weapon, bool allowed = true)
+        {
+            SetFilterBit(GetFilterBit(weapon), allowed);
+        }
+
+        public static void SetAllowed(MissileType missile, bool allowed = true)
+        {
+            SetFilterBit(GetFilterBit(missile), allowed);
         }
 
         private static WeaponType FindFirstUnsedAllowed(List<WeaponType> weapons, int filter)

--- a/GameMod/MPMatchInfo.cs
+++ b/GameMod/MPMatchInfo.cs
@@ -17,6 +17,10 @@ namespace GameMod
         private static bool[] secondarypowerups = new bool[8];
         private static bool disabledpowerups = false;
 
+        private static int loadout_bitmask = MPLoadouts.MASK_DEFAULT;
+        private static List<string> loadouts = new List<string>();
+        private static string loadouts_mode = "undefined";
+
         public static bool Displayed = false;
 
         public static void DrawMatchInfo(UIElement uie, Vector2 position)
@@ -35,6 +39,12 @@ namespace GameMod
                         disabledpowerups = true;
                     }
                 }
+            }
+
+            if (loadout_bitmask != MPModPrivateData.LoadoutFilterBitmask) {
+                loadout_bitmask = MPModPrivateData.LoadoutFilterBitmask;
+                loadouts = MPLoadouts.GetItems(loadout_bitmask, ref loadouts_mode);
+                //loadouts_additional = MPLoadouts.GetAdditionalAllowedItems(loadout_bitmask);
             }
 
             bool show = false;
@@ -167,6 +177,14 @@ namespace GameMod
                         uie.DrawStringSmall(Player.MissileNames[s], position, TEXT_SIZE, StringOffset.RIGHT, UIManager.m_col_ui2, uie.m_alpha);
                         position.y += LINE_SIZE;
                     }
+                }
+            }
+            if (NetworkMatch.m_force_loadout == 0 && loadouts.Count > 0) {
+                show = true;
+                uie.DrawStringSmall(loadouts_mode, position - Vector2.right * LEFT_OFFSET, TEXT_SIZE, StringOffset.LEFT, UIManager.m_col_ui1, 1f, 100f);
+                foreach(var s in loadouts) {
+                        uie.DrawStringSmall(s, position, TEXT_SIZE, StringOffset.RIGHT, UIManager.m_col_ui2, uie.m_alpha);
+                        position.y += LINE_SIZE;
                 }
             }
 

--- a/GameMod/MPMatchPresets.cs
+++ b/GameMod/MPMatchPresets.cs
@@ -66,7 +66,8 @@ namespace GameMod
                 assistScoring = Menus.mms_assist_scoring,
                 teamCount = MPTeams.MenuManagerTeamCount,
                 shipMeshCollider = Menus.mms_collision_mesh,
-                thunderboltPassthrough = MPThunderboltPassthrough.isAllowed
+                thunderboltPassthrough = MPThunderboltPassthrough.isAllowed,
+                loadoutFilterBitmask = MPLoadouts.LoadoutFilterBitmask
             });
 
             presets.Add(new MPMatchPreset
@@ -107,7 +108,8 @@ namespace GameMod
                 assistScoring = true,
                 teamCount = 2,
                 shipMeshCollider = 0,
-                thunderboltPassthrough = false
+                thunderboltPassthrough = false,
+                loadoutFilterBitmask = MPLoadouts.MASK_DEFAULT
             });
 
             presets.Add(new MPMatchPreset
@@ -148,7 +150,8 @@ namespace GameMod
                 teamCount = 2,
                 shipMeshCollider = 0,
                 damageNumbers = true,
-                thunderboltPassthrough = false
+                thunderboltPassthrough = false,
+                loadoutFilterBitmask = MPLoadouts.MASK_DEFAULT
             });
 
             GameManager.m_gm.StartCoroutine(GetMatchPresets());
@@ -194,6 +197,7 @@ namespace GameMod
             public int shipMeshCollider = 0;
             public float colliderScale = 1f;
             public bool thunderboltPassthrough;
+            public int loadoutFilterBitmask = MPLoadouts.MASK_DEFAULT;
 
             public void Apply()
             {
@@ -241,6 +245,7 @@ namespace GameMod
                 Menus.mms_collision_mesh = this.shipMeshCollider;
                 MPColliderSwap.colliderScale = this.colliderScale;
                 MPThunderboltPassthrough.isAllowed = this.thunderboltPassthrough;
+                MPLoadouts.LoadoutFilterBitmask = this.loadoutFilterBitmask;
             }
         }
 

--- a/GameMod/MPModPrivateData.cs
+++ b/GameMod/MPModPrivateData.cs
@@ -1277,6 +1277,12 @@ END_ENTRY
             set { MPAudioTaunts.AServer.server_supports_audiotaunts = value; }
         }
 
+        public static int LoadoutFilterBitmask
+        {
+            get { return MPLoadouts.LoadoutFilterBitmask; }
+            set { MPLoadouts.LoadoutFilterBitmask = value; }
+        }
+
         public static JObject Serialize()
         {
             JObject jobject = new JObject();
@@ -1304,6 +1310,7 @@ END_ENTRY
             jobject["thunderboltpassthrough"] = ThunderboltPassthrough;
             jobject["damagenumbers"] = DamageNumbers;
             jobject["audiotauntsupport"] = AudioTauntsSupported;
+            jobject["loadoutfilter"] = (int)LoadoutFilterBitmask;
             return jobject;
         }
 
@@ -1337,6 +1344,7 @@ END_ENTRY
             ThunderboltPassthrough = root["thunderboltpassthrough"].GetBool(false);
             DamageNumbers = root["damagenumbers"].GetBool(false);
             AudioTauntsSupported = root["audiotauntsupport"].GetBool(false);
+            LoadoutFilterBitmask = root["loadoutfilter"].GetInt(MPLoadouts.MASK_DEFAULT);
         }
 
         public static string GetModeString(MatchMode mode)
@@ -1631,6 +1639,7 @@ END_ENTRY
             MPModPrivateData.ShipMeshCollider = Menus.mms_collision_mesh;
             MPModPrivateData.ColliderScale = MPColliderSwap.colliderScale;
             MPModPrivateData.ThunderboltPassthrough = MPThunderboltPassthrough.isAllowed;
+            MPModPrivateData.LoadoutFilterBitmask = MPLoadouts.LoadoutFilterBitmask;
             if (Menus.mms_mp_projdata_fn == "STOCK") {
                 MPModPrivateData.CustomProjdata = string.Empty;
             } else {

--- a/GameMod/MPModifiers.cs
+++ b/GameMod/MPModifiers.cs
@@ -86,7 +86,7 @@ namespace GameMod
         [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
         class MPModifiers_UIElement_DrawMpMatchSetup
         {
-
+            /*
             static void ModifierSettings(UIElement uie, ref Vector2 position)
             {
                 position.y += 62f;
@@ -115,7 +115,7 @@ namespace GameMod
 
                     yield return code;
                 }
-            }
+            }*/
 
             private static void Postfix(UIElement __instance)
             {

--- a/GameMod/MPTweaks.cs
+++ b/GameMod/MPTweaks.cs
@@ -286,7 +286,7 @@ namespace GameMod {
             caps.Add("ModVersion", OlmodVersion.FullVersionString);
             caps.Add("Modded", Core.GameMod.Modded ? "1" : "0");
             caps.Add("ModsLoaded", Core.GameMod.ModsLoaded);
-            caps.Add("SupportsTweaks", "changeteam,deathreview,sniper,jip,nocompress_0_3_6,customloadouts,damagenumbers,ctfjoin,efirepacket" + (MPAudioTaunts.AClient.active ? ",audiotaunts":""));
+            caps.Add("SupportsTweaks", "changeteam,deathreview,sniper,jip,nocompress_0_3_6,customloadouts,damagenumbers,ctfjoin,efirepacket,noprimaries" + (MPAudioTaunts.AClient.active ? ",audiotaunts":""));
             caps.Add("ModPrivateData", "1");
             caps.Add("ClassicWeaponSpawns", "1");
             caps.Add("NetVersion", MPTweaks.NET_VERSION.ToString());

--- a/GameMod/MPTweaks.cs
+++ b/GameMod/MPTweaks.cs
@@ -286,7 +286,7 @@ namespace GameMod {
             caps.Add("ModVersion", OlmodVersion.FullVersionString);
             caps.Add("Modded", Core.GameMod.Modded ? "1" : "0");
             caps.Add("ModsLoaded", Core.GameMod.ModsLoaded);
-            caps.Add("SupportsTweaks", "changeteam,deathreview,sniper,jip,nocompress_0_3_6,customloadouts,damagenumbers,ctfjoin,efirepacket,noprimaries" + (MPAudioTaunts.AClient.active ? ",audiotaunts":""));
+            caps.Add("SupportsTweaks", "changeteam,deathreview,sniper,jip,nocompress_0_3_6,customloadouts,damagenumbers,ctfjoin,efirepacket,incompleteloadouts" + (MPAudioTaunts.AClient.active ? ",audiotaunts":""));
             caps.Add("ModPrivateData", "1");
             caps.Add("ClassicWeaponSpawns", "1");
             caps.Add("NetVersion", MPTweaks.NET_VERSION.ToString());

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -342,8 +342,7 @@ namespace GameMod {
 
         private static void DrawBacklinkButtonInPowerupMenu(UIElement uie)
         {
-            Vector2 position = Vector2.up * (UIManager.UI_TOP + 700f);
-            uie.SelectAndDrawHalfItem2("ALLOWED LOADOUTS", position - Vector2.right * 360f, 30, false);
+            uie.SelectAndDrawHalfItem2("ALLOWED LOADOUTS", new Vector2(-473f, 214), 30, false);
         }
 
         private static void ResetCenter(UIElement uie, ref Vector2 position)


### PR DESCRIPTION
Similar to the "Allowed Powerups" menu, there now is an additional menu where the weapons can be allowed/disallowed in the player's loadouts.

This also allows to play games without any secondaries, or without any primaries - or without any weapons at all (happy flaring!).

When loadout restrictions are in place, they are shown in the lobby like all other non-standard match settings.

Weapons in the players' loadouts which are disabled will be replaced by allowed ones (in the order they are defined in the enum in the Overload source code). While there currently is no way for players to select stuff like Lancer or Devs for their loadout, you can exploit this mechanism to force these into the loadout by forbidding all others. I.e. you can force timebomb+devs in the loadout and still allow free choice about all the primaries.

This also allows to set up an "Tirex" OTL match preset. The required setting for this would be 

`"loadoutFilterBitmask": 3909`

Notes on backwards compatibility:
- Both vanilla overload and older olmod versions conceptually when at least 2 secondaries and 2 primaries are still allowed in the match.
- Clients which do not support custom loadouts at all may show the wrong weapons in the in-game loadout selection menu, but still will only get allowed weapons when the ship spawns. Mapping the restriced loadouts to the available loadouts for such clients is done in a best-effort strategy.
- If in one category less than 2 weapons are allowed, only clients having this patch (marked by `incompleteloadouts` feature flag) can connect, other clients will be disconnected with a "This match enforces INCOMPLETE LOADOUTS, which is not supported for legacy clients" message (they would otherwise crash)

This is an joint effort from derhass (main code logic) and luponix (most of the UI changes)