### PR TITLE
Fix null exception spam when running Overload in vr

### DIFF
--- a/GameMod/Shaders.cs
+++ b/GameMod/Shaders.cs
@@ -10,7 +10,7 @@ namespace GameMod {
                 return true;
             }
 
-            __instance.mat = new Material((Shader)null);
+            __instance.mat = new Material(Shader.Find("Standard"));
             __instance.meshRender.material = __instance.mat;
             if (__instance._atlas && __instance._atlas.texture) {
                 __instance.mat.mainTexture = __instance._atlas.texture;


### PR DESCRIPTION
```
NullReferenceException
at (wrapper managed-to-native) UnityEngine.Material.Internal_CreateWithShader (UnityEngine.Material,UnityEngine.Shader) <0x00072>
at UnityEngine.Material..ctor (UnityEngine.Shader) <0x00024>
at GameMod.Shaders_CreateMat.Prefix (ProFlareBatch) <0x0005f>
at (wrapper dynamic-method) ProFlareBatch.ProFlareBatch.CreateMat_Patch1 (ProFlareBatch) <0x00026>
at ProFlareBatch.Update () <0x00178>
```