### PR TITLE
Console key fix and console_key command line argument

### DIFF
--- a/GameMod/Console.cs
+++ b/GameMod/Console.cs
@@ -10,6 +10,7 @@ namespace GameMod {
     {
         public static bool KeyEnabled;
         public static int CustomUIColor;
+        public static string[] ActivationChars = { "`", "~", "ö" };
 
         private static MethodInfo _GameManager_InitializeMissionList_Method = typeof(GameManager).GetMethod("InitializeMissionList", AccessTools.all);
         public static void CmdReloadMissions()
@@ -347,9 +348,68 @@ namespace GameMod {
     [HarmonyPatch(typeof(uConsoleInput), "ProcessActivationInput")]
     class ConsoleEnablePatch
     {
+        private static bool lastFramePresent = false;
+
+        private static bool ActivationCharTyped()
+        {
+            string s = Input.inputString;
+            if (string.IsNullOrEmpty(s)) return false;
+            foreach (string c in Console.ActivationChars)
+                if (!string.IsNullOrEmpty(c) && s.Contains(c))
+                    return true;
+            return false;
+        }
+
         private static bool Prefix()
         {
-            return Console.KeyEnabled || uConsole.IsOn();
+            bool down = ActivationCharTyped() && !lastFramePresent;
+            bool up = !ActivationCharTyped() && lastFramePresent;
+            lastFramePresent = ActivationCharTyped();
+
+            if (!(Console.KeyEnabled || uConsole.IsOn()))
+                return false;
+
+            if (down)
+            {
+                if (!uConsole.IsOn())
+                {
+                    uConsole.TurnOn();
+                    uConsole.m_GUI.InputFieldMoveCaretToEnd();
+                    uConsole.m_GUI.InputFieldSetFocus();
+                }
+                else
+                {
+                    uConsole.TurnOff();
+                    uConsole.m_GUI.InputFieldDeactivate();
+                }
+            }
+            else if (up && uConsole.IsOn())
+            {
+                uConsole.m_GUI.InputFieldSetFocus();
+            }
+
+            return false;
+        }
+
+        // remove the activation character from the input field
+        private static void Postfix()
+        {
+            string text = uConsole.m_GUI.InputFieldGetText();
+            if (string.IsNullOrEmpty(text)) return;
+
+            string stripped = text;
+            foreach (string c in Console.ActivationChars)
+                if (!string.IsNullOrEmpty(c))
+                    stripped = stripped.Replace(c, "");
+
+            if (stripped == text) return;
+            if (stripped.Length == 0)
+                uConsole.m_GUI.InputFieldClearText();
+            else
+            {
+                uConsole.m_GUI.InputFieldSetText(stripped);
+                uConsole.m_GUI.InputFieldMoveCaretToEnd();
+            }
         }
     }
 

--- a/GameMod/GameMod.cs
+++ b/GameMod/GameMod.cs
@@ -91,8 +91,14 @@ namespace GameMod.Core {
             }
 
             uConsole.RegisterCommand("getval", "Gets the value of a specified variable -- \"getval [static class].[field]\" (classes can be nested to reach instance fields)", new uConsole.DebugCommand(GetVal));
-            
-            if (FindArg("-telemetry")) 
+
+            // sets the console activation character list (seperated by comma)
+            if (FindArgVal("-console_key", out string consoleKey))
+                if (!String.IsNullOrEmpty(consoleKey)){
+                    global::GameMod.Console.ActivationChars = consoleKey.Split(',');
+                }
+
+            if (FindArg("-telemetry"))
                 TelemetryMod.telemetry_enabled = true;
 
             if (FindArgVal("-telemetry-ip", out string ip_string)){


### PR DESCRIPTION
the old uConsole toggle used  Input.GetKeyDown.
On some systems that leads to the key not being pressable or shifted.
By using Input.inputString we can avoid keycode, scanout and unity enum mapping nonsense and only consider the result

(and also add a new command line argument to make the char configurable:  -console_key key,key,key ...)
